### PR TITLE
Actually make env variable optional

### DIFF
--- a/HQSmokeTests/TestBase/environmentSetupPage.py
+++ b/HQSmokeTests/TestBase/environmentSetupPage.py
@@ -100,7 +100,7 @@ def load_settings_from_environment():
         if var in os.environ:
             settings[name] = os.environ[var]
     if "url" not in settings:
-        env = os.environ["DIMAGIQA_ENV"] or "staging"
+        env = os.environ.get("DIMAGIQA_ENV") or "staging"
         subdomain = "www" if env == "production" else env
         settings["url"] = f"https://{subdomain}.commcarehq.org/"
     return settings


### PR DESCRIPTION
Follow-up to https://github.com/dimagi/dimagi-qa/pull/43, a tiny tweak to make `DIMAGIQA_ENV` optional (meaning allow it to not be set) when `DIMAGIQA_URL` is not provided. So far this is not a problem because it is always set (sometimes with an empty value).