### PR TITLE
Missing workflow for web user invitation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -48,6 +48,7 @@ jobs:
         DIMAGIQA_BS_KEY: ${{ secrets.DIMAGIQA_BS_KEY }}
         DIMAGIQA_STAGING_AUTH_KEY: ${{ secrets.DIMAGIQA_STAGING_AUTH_KEY }}
         DIMAGIQA_PROD_AUTH_KEY: ${{ secrets.DIMAGIQA_PROD_AUTH_KEY }}
+        DIMAGIQA_INVITED_WEBUSER_PASSWORD: ${{ secrets.DIMAGIQA_INVITED_WEBUSER_PASSWORD }}
       run: |
         echo "client_payload: ${{ toJson(github.event.client_payload) }}"
         echo "NOW=$(date +'%m-%d %H:%M')" >> $GITHUB_ENV

--- a/HQSmokeTests/settings-sample.cfg
+++ b/HQSmokeTests/settings-sample.cfg
@@ -6,3 +6,4 @@ bs_user =
 bs_key =
 staging_auth_key =
 prod_auth_key =
+invited_webuser_password =

--- a/HQSmokeTests/testCases/conftest.py
+++ b/HQSmokeTests/testCases/conftest.py
@@ -32,7 +32,8 @@ def environment_settings():
             """
     settings = {}
     for name in ["url", "login_username", "login_password", "mail_username",
-                 "mail_password", "bs_user", "bs_key", "staging_auth_key", "prod_auth_key"]:
+        "mail_password", "bs_user", "bs_key", "staging_auth_key", "prod_auth_key", "invited_webuser_password"]:
+
         var = f"DIMAGIQA_{name.upper()}"
         if var in os.environ:
             settings[name] = os.environ[var]
@@ -51,7 +52,7 @@ def settings(environment_settings):
         settings["CI"] = "true"
         if any(x not in settings for x in ["url", "login_username", "login_password",
                                            "mail_username", "mail_password", "bs_user", "bs_key", "staging_auth_key",
-                                           "prod_auth_key"]):
+                                           "prod_auth_key", "invited_webuser_password"]):
             lines = environment_settings.__doc__.splitlines()
             vars_ = "\n  ".join(line.strip() for line in lines if "DIMAGIQA_" in line)
             raise RuntimeError(

--- a/HQSmokeTests/testCases/test_02_users.py
+++ b/HQSmokeTests/testCases/test_02_users.py
@@ -1,14 +1,17 @@
 from HQSmokeTests.userInputs.generate_random_string import fetch_random_string
+# from HQSmokeTests.testPages.base.login_page import LoginPage
 from HQSmokeTests.testPages.home.home_page import HomePage
 from HQSmokeTests.testPages.users.mobile_workers_page import MobileWorkerPage
 from HQSmokeTests.testPages.users.group_page import GroupPage
 from HQSmokeTests.testPages.users.web_user_page import WebUsersPage
 
+# from HQSmokeTests.userInputs.user_inputs import UserData
+
+
 """"Contains test cases related to the User's Mobile Worker module"""
 
 
 def test_case_02_create_mobile_worker(driver):
-
     worker = MobileWorkerPage(driver)
     worker.mobile_worker_menu()
     worker.create_mobile_worker()
@@ -18,7 +21,6 @@ def test_case_02_create_mobile_worker(driver):
 
 
 def test_case_03_create_and_assign_user_field(driver):
-
     create = MobileWorkerPage(driver)
     create.mobile_worker_menu()
     create.edit_user_field()
@@ -33,7 +35,6 @@ def test_case_03_create_and_assign_user_field(driver):
 
 
 def test_case_05_create_group_and_assign_user(driver):
-
     menu = HomePage(driver)
     menu.users_menu()
     visible = GroupPage(driver)
@@ -51,14 +52,12 @@ def test_case_05_edit_user_groups(driver):
 
 
 def test_case_10_download_and_upload_users(driver):
-
     user = MobileWorkerPage(driver)
     user.download_mobile_worker()
     user.upload_mobile_worker()
 
 
 def test_case_04_deactivate_user(driver):
-
     user = MobileWorkerPage(driver)
     user.mobile_worker_menu()
     user.deactivate_user()
@@ -66,7 +65,6 @@ def test_case_04_deactivate_user(driver):
 
 
 def test_case_04_reactivate_user(driver):
-
     user = MobileWorkerPage(driver)
     user.mobile_worker_menu()
     user.reactivate_user()
@@ -94,16 +92,7 @@ def test_cleanup_items_in_users_menu(driver):
     print("Deleted the group")
 
 
-def test_case_13_new_webuser_invitation(driver):
-
-    webuser = WebUsersPage(driver)
-    webuser.invite_new_web_user('admin')
-    webuser.assert_invite()
-    webuser.delete_invite()
-
-
 def test_case_54_add_custom_user_data_profile_to_mobile_worker(driver):
-
     create = MobileWorkerPage(driver)
     create.mobile_worker_menu()
     create.create_new_mobile_worker()
@@ -126,3 +115,15 @@ def test_case_54_add_custom_user_data_profile_to_mobile_worker(driver):
     create.click_fields()
     create.remove_user_field()
     create.save_field()
+
+
+def test_case_13_new_webuser_invitation(driver, settings):
+    webuser = WebUsersPage(driver)
+    yahoo_password = settings['invited_webuser_password']
+    webuser.invite_new_web_user('admin')
+    webuser.assert_invitation_sent()
+    # webuser.assert_invitation_received(UserData.yahoo_url, UserData.yahoo_user_name, yahoo_password)
+    # webuser.accept_webuser_invite(UserData.yahoo_user_name, yahoo_password)
+    # login = LoginPage(driver, settings["url"])
+    # login.login(settings["login_username"], settings["login_password"])
+    webuser.delete_invite()

--- a/HQSmokeTests/testCases/test_02_users.py
+++ b/HQSmokeTests/testCases/test_02_users.py
@@ -119,9 +119,9 @@ def test_case_54_add_custom_user_data_profile_to_mobile_worker(driver):
 
 def test_case_13_new_webuser_invitation(driver, settings):
     webuser = WebUsersPage(driver)
-    yahoo_password = settings['invited_webuser_password']
     webuser.invite_new_web_user('admin')
     webuser.assert_invitation_sent()
+    # yahoo_password = settings['invited_webuser_password']
     # webuser.assert_invitation_received(UserData.yahoo_url, UserData.yahoo_user_name, yahoo_password)
     # webuser.accept_webuser_invite(UserData.yahoo_user_name, yahoo_password)
     # login = LoginPage(driver, settings["url"])

--- a/HQSmokeTests/testPages/users/web_user_page.py
+++ b/HQSmokeTests/testPages/users/web_user_page.py
@@ -1,5 +1,9 @@
 import time
+import re
+from datetime import date
+from datetime import datetime
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
@@ -21,32 +25,112 @@ class WebUsersPage(BasePage):
         self.email_input = (By.XPATH, "//input[@class='emailinput form-control']")
         self.select_project_role_id = "id_role"
         self.send_invite = (By.XPATH, "//button[contains(text(),'Send Invite')]")
-        self.delete_confirm_button = (By.XPATH, "//button[@data-bind='click: $root.removeInvitation']")
-        self.verify_user = (By.XPATH,
-                            "//td[.//text()[contains(.,'" + UserData.web_user_mail + "')]]/following-sibling::td[.//text()[contains(.,'Delivered')]]")
+        self.delete_confirm_invitation = (By.XPATH, "//button[@data-bind = 'click: $root.removeInvitation']")
+        self.delete_confirm_webuser = (By.XPATH,
+                                       "(//td[.//text()[contains(.,'" + UserData.yahoo_user_name + "')]]/following-sibling::td//i[@class='fa fa-trash'])[last()]")
+        self.delete_success = (By.XPATH, "//div[@class='alert alert-margin-top fade in html alert-success']")
+        self.verify_user = (By.XPATH,"//td[.//text()[contains(.,'" + UserData.yahoo_user_name  + "')]]/following-sibling::td[.//text()[contains(.,'Delivered')]]")
         self.remove_user_invite = (By.XPATH,
-                                   "//td[.//text()[contains(.,'" + UserData.web_user_mail + "')]]/following-sibling::td//i[@class='fa fa-trash']")
+                                   "//td[.//text()[contains(.,'" + UserData.yahoo_user_name  + "')]]/following-sibling::td//i[@class='fa fa-trash']")
+        self.login_username = (By.ID, "login-username")
+        self.next_button = (By.ID, "login-signin")
+        self.login_password = (By.NAME, "password")
+        self.signin_button = (By.ID, "login-signin")
+        self.mail_icon = (By.XPATH, "//div[@class= 'icon mail']")
+        self.latest_mail = (By.XPATH, "(//span[contains(@title,'Invitation from')])[1]")
+        self.invitation_received_date = (By.XPATH, '//div[@data-test-id="message-date"]')
+        self.accept_invitation = (By.XPATH, "//*[contains(text(), 'Accept Invitation')]")
+        self.accept_invitation_hq = (By.XPATH, "//button[contains(text(), 'Accept Invitation')]")
+        self.full_name = (By.NAME, "full_name")
+        self.create_password = (By.NAME, "password")
+        self.check_checkbox = (By.ID, "id_eula_confirmed")
+        self.create_button = (By.XPATH, "//button[@type='submit']")
+        self.settings = (By.XPATH, "//a[@data-action='Click Gear Icon']")
+        self.sign_out = (By.XPATH, "//a[contains(@data-label,'Sign Out')]")
+        self.creation_success = (By.XPATH, "//div[@class='alert alert-margin-top fade in alert-success']")
+        self.password_textbox = (By.ID, 'id_auth-password')
+        self.submit_button_xpath = (By.XPATH, '(//button[@type="submit"])[last()]')
+        self.existing_error = (By.ID, 'error_1_id_email')
 
     def invite_new_web_user(self, role):
         self.wait_to_click(self.users_menu_id)
         self.wait_to_click(self.web_users_menu)
-        # delete invitation if already sent
-        self.delete_invite()
         self.wait_to_click(self.invite_web_user_button)
-        self.wait_to_clear_and_send_keys(self.email_input, UserData.web_user_mail)
+        self.wait_to_clear_and_send_keys(self.email_input, UserData.yahoo_user_name)
         select_role = Select(self.driver.find_element_by_id(self.select_project_role_id))
         select_role.select_by_value(role)
         self.wait_to_click(self.send_invite)
+        if self.is_visible_and_displayed(self.existing_error):
+            self.delete_invite()
+            self.wait_to_click(self.invite_web_user_button)
+            self.wait_to_clear_and_send_keys(self.email_input, UserData.yahoo_user_name)
+            select_role = Select(self.driver.find_element_by_id(self.select_project_role_id))
+            select_role.select_by_value(role)
+            self.wait_to_click(self.send_invite)
 
 
-    def assert_invite(self):
-        time.sleep(5)
+    def assert_invitation_sent(self):
+        time.sleep(10)
         self.wait_to_click(self.users_menu_id)
         self.wait_to_click(self.web_users_menu)
-        assert self.is_displayed(self.verify_user), "Unable to find invite."
+        assert self.is_visible_and_displayed(self.verify_user), "Unable to find delivered invite."
         print("Web user invitation sent successfully")
+        self.wait_to_click(self.settings)
+        self.wait_to_click(self.sign_out)
+        print("Signed out successfully")
 
-    def delete_invite(self ):
+    def assert_invitation_received(self, mail_url, mail_username, mail_password):
+        self.driver.get(mail_url)
+        self.wait_to_clear_and_send_keys(self.login_username, mail_username)
+        self.wait_and_sleep_to_click(self.next_button)
+        self.wait_to_clear_and_send_keys(self.login_password, mail_password)
+        self.wait_and_sleep_to_click(self.signin_button)
+        self.wait_to_click(self.mail_icon)
+        self.click(self.latest_mail)
+        self.verify_invitation_received()
+
+    def verify_invitation_received(self):
+        received_date_on_yahoo = self.get_text(self.invitation_received_date)
+        stripped_strings = re.findall(r'\w+', received_date_on_yahoo)
+        unwanted = [0, 2]
+        for ele in unwanted:
+            del stripped_strings[ele]
+        stripped_strings.insert(2, str(date.today().year))
+        invitation_received_datetime = datetime.strptime(" ".join(stripped_strings), '%d %b %Y %I %M %p')
+        current_time = datetime.now()
+        time_difference = round((current_time - invitation_received_datetime).total_seconds())
+        print(time_difference)
+        assert time_difference in range(0, 200), "Unable to find invite"
+
+
+    def accept_webuser_invite(self, mail_usename, mail_password):
+        self.wait_to_click(self.accept_invitation)
+        self.switch_to_next_tab()
+        try:
+            self.wait_to_clear_and_send_keys(self.full_name, mail_usename)
+            self.wait_to_clear_and_send_keys(self.create_password, mail_password)
+            self.wait_to_click(self.check_checkbox)
+            self.wait_to_click(self.create_button)
+        except TimeoutException:
+            self.send_keys(self.password_textbox, mail_password)
+            self.wait_to_click(self.submit_button_xpath)
+        self.wait_to_click(self.accept_invitation_hq)
+        assert "CommCare HQ" in self.driver.title, "Invitation Acceptance Failed"
+        self.wait_to_click(self.settings)
+        self.wait_to_click(self.sign_out)
+        print("Signed out successfully")
+
+    def delete_invite(self):
+        self.wait_to_click(self.users_menu_id)
+        self.wait_to_click(self.web_users_menu)
         self.wait_to_click(self.remove_user_invite)
-        self.wait_to_click(self.delete_confirm_button)
+        try:
+            time.sleep(2)
+            self.js_click(self.delete_confirm_invitation)
+        except TimeoutException:
+            time.sleep(2)
+            self.js_click(self.delete_confirm_webuser)
         print("Invitation deleted")
+
+
+

--- a/HQSmokeTests/testPages/users/web_user_page.py
+++ b/HQSmokeTests/testPages/users/web_user_page.py
@@ -68,18 +68,17 @@ class WebUsersPage(BasePage):
             select_role.select_by_value(role)
             self.wait_to_click(self.send_invite)
 
-
     def assert_invitation_sent(self):
         time.sleep(10)
         self.wait_to_click(self.users_menu_id)
         self.wait_to_click(self.web_users_menu)
         assert self.is_visible_and_displayed(self.verify_user), "Unable to find delivered invite."
         print("Web user invitation sent successfully")
+
+    def assert_invitation_received(self, mail_url, mail_username, mail_password):
         self.wait_to_click(self.settings)
         self.wait_to_click(self.sign_out)
         print("Signed out successfully")
-
-    def assert_invitation_received(self, mail_url, mail_username, mail_password):
         self.driver.get(mail_url)
         self.wait_to_clear_and_send_keys(self.login_username, mail_username)
         self.wait_and_sleep_to_click(self.next_button)

--- a/HQSmokeTests/userInputs/user_inputs.py
+++ b/HQSmokeTests/userInputs/user_inputs.py
@@ -30,8 +30,7 @@ class UserData:
 
     # Phone Number
     area_code = "91"
-    # invite_web_user user email
-    web_user_mail = 'automation.user.commcarehq+test@gmail.com'
+
 
     #  web app
     app_type = "Applications"
@@ -61,3 +60,6 @@ class UserData:
     text_value = 'name'
     random_value = 'enter_a_random_value'
 
+    """New web user invitation"""
+    yahoo_url = "https://login.yahoo.com/"
+    yahoo_user_name = 'automation_user_commcare@yahoo.com'


### PR DESCRIPTION
Earlier the invite webuser test case had a couple of missing workflows. This PR deals with the same.

Basically added workflows:

-  to verify invitation mail is sent
- accept web user invitation mail and check if that's successful

However, this fails on CI due to reCaptcha. So, commented the code, but the idea is to push the new code to master and address it later as a part of [QA-4181](https://dimagi-dev.atlassian.net/browse/QA-4181)