### PR TITLE
Added description for config parameters used for HQ tests

### DIFF
--- a/HQSmokeTests/settings-sample.cfg
+++ b/HQSmokeTests/settings-sample.cfg
@@ -1,9 +1,17 @@
 [default]
+# This is the environment url of commcare
 url = https://www.commcarehq.org/
+# Login username of the webuser
 login_username =
+# Login password of the webuser
 login_password =
+# This is a preconfigured browsertack username for mobile tests
 bs_user =
+# This is a preconfigured browsertack key used for mobile tests
 bs_key =
+# This is a preconfigured authentication key used for 2FA tests on staging
 staging_auth_key =
+# This is a preconfigured authentication key used for 2FA tests on prod
 prod_auth_key =
+# This is a preconfigured password for the user used to test web user invitation tests
 invited_webuser_password =


### PR DESCRIPTION
A small change to make the config parameters more understandable for the end user.