### PR TITLE
Fix for Reassign Cases test failing on Prod

### DIFF
--- a/HQSmokeTests/testCases/test_06_data.py
+++ b/HQSmokeTests/testCases/test_06_data.py
@@ -16,10 +16,10 @@ def test_case_29_import_cases(driver):
     imp.replace_property_and_upload()
 
 
-def test_case_30_reassign_cases(driver):
+def test_case_30_reassign_cases(driver, settings):
 
     export = ExportDataPage(driver)
-    reassign = ReassignCasesPage(driver)
+    reassign = ReassignCasesPage(driver, settings)
     export.data_tab()
     reassign.get_cases()
     reassign.reassign_case()

--- a/HQSmokeTests/testPages/data/reassign_cases_page.py
+++ b/HQSmokeTests/testPages/data/reassign_cases_page.py
@@ -10,9 +10,10 @@ from HQSmokeTests.userInputs.user_inputs import UserData
 
 class ReassignCasesPage(BasePage):
 
-    def __init__(self, driver):
+    def __init__(self, driver, settings):
         super().__init__(driver)
 
+        self.env_url = settings["url"]
         self.reassign_cases_menu = (By.LINK_TEXT, "Reassign Cases")
         self.apply = (By.ID, "apply-btn")
         self.case_type = (By.ID, "report_filter_case_type")
@@ -45,5 +46,8 @@ class ReassignCasesPage(BasePage):
         self.wait_to_click(self.apply)
         time.sleep(5)
         self.wait_for_element(self.new_owner_name)
-        reassigned_username = self.get_text(self.new_owner_name).split('"')[0]
+        if "www" in self.env_url:
+            reassigned_username = self.get_text(self.new_owner_name).split('@')[0]
+        else:
+            reassigned_username = self.get_text(self.new_owner_name).split('"')[0]
         assert reassigned_username in assigned_username


### PR DESCRIPTION
The Reassign Cases test was failing on Prod env because it was unable to assert the username to which the case was reassigned due to different users were being used on staging & prod. 

Therefore, I have added an if condition to assert accordingly depending on the environment on which the test is running. 