### PR TITLE
Updated API Gitaction workflow

### DIFF
--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -5,10 +5,6 @@ name: Python Request API
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
   repository_dispatch:
     types: [ deploy_success ]
 
@@ -61,7 +57,7 @@ jobs:
         username: ${{secrets.DIMAGIQA_MAIL_USERNAME}}
         password: ${{secrets.DIMAGIQA_MAIL_PASSWORD}}
         subject: FAIL - Request API Tests[#${{github.run_number}}] on branch "${{ github.ref_name }}", ${{env.NOW}}
-        to: qa-automation@dimagi.com
+        to: qa@dimagi.com
         from: <${{secrets.DIMAGIQA_MAIL_USERNAME}}>
         html_body: file:////home/runner/work/dimagi-qa/dimagi-qa/RequestAPI/email_fail.html
         attachments: /home/runner/work/dimagi-qa/dimagi-qa/report.html
@@ -76,7 +72,7 @@ jobs:
         username: ${{secrets.DIMAGIQA_MAIL_USERNAME}}
         password: ${{secrets.DIMAGIQA_MAIL_PASSWORD}}
         subject: PASS - Request API Tests[#${{github.run_number}}] on branch "${{ github.ref_name }}", ${{env.NOW}}
-        to: qa-automation@dimagi.com
+        to: qa@dimagi.com
         from: <${{secrets.DIMAGIQA_MAIL_USERNAME}}>
         html_body: file:////home/runner/work/dimagi-qa/dimagi-qa/RequestAPI/email_pass.html
         attachments: /home/runner/work/dimagi-qa/dimagi-qa/report.html


### PR DESCRIPTION
- Earlier mails were not being triggered to the QA team, changed that to qa@dimagi.com
- Removed job trigger on push and pull, because it is not likely to fail due to that (unless changes made to it specifically)