### PR TITLE
add job name with environment

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-
+    name: Smoke on '${{ github.event.client_payload.environment || 'staging' }}'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This should make it easier to see which env a job is running on without having to load the log output.

![image](https://user-images.githubusercontent.com/249606/178709073-860ee42f-1e7f-4b36-b24b-3956c7991714.png)
