### PR TITLE
fix for testcase 15,16 and 38

### DIFF
--- a/HQSmokeTests/testPages/android/android_screen.py
+++ b/HQSmokeTests/testPages/android/android_screen.py
@@ -14,7 +14,7 @@ class AndroidScreen:
             "browserstack.key": settings["bs_key"],
 
             # Set URL of the application under test
-            "app": "bs://96463cb5b72414e0d51b8274ce456e177fd21dd3",
+            "app": "bs://ab4039a89c9868f192dd3e541beab2a4b3a3ad48",
 
             # Specify device and os_version for testing
             "device": "Google Pixel 4 XL",

--- a/HQSmokeTests/testPages/webapps/web_apps_page.py
+++ b/HQSmokeTests/testPages/webapps/web_apps_page.py
@@ -36,7 +36,7 @@ class WebAppsPage(BasePage):
         self.enter_value_area = (By.XPATH, "//label[./div[./span[contains(text(),'Enter a random value')]]]/following-sibling::div[@data-bind='css: controlWidth']//div/textarea")
         self.update_value_area = (By.XPATH, "//label[./div[./span[contains(text(),'Update')]]]/following-sibling::div[@data-bind='css: controlWidth']//div/textarea")
         self.form_link = (By.XPATH, "//*[text()='" + UserData.form_name + "']")
-        self.form_case_name_input = (By.XPATH, "//textarea[@class='textfield form-control']")
+        self.form_case_name_input = (By.XPATH, "//textarea[contains(@class,'textfield form-control')]")
         self.form_submit_button = (By.XPATH, "//button[@class='submit btn btn-primary']")
         self.success_message = (By.XPATH, "//p[text()='Form successfully saved!']")
         self.show_full_menu_link = (By.LINK_TEXT, "Show Full Menu")


### PR DESCRIPTION
## Summary
Fixes for Testcase 15_16 and 38

## Description
For testcase 15_16, updated locator of webapps textarea input field
For testcase 38, old apk expired in browserstack so uploaded the apk and updated app_url value in script


### Link to Jira Ticket (if applicable)
<!--
Provide link to Jira ticket if applicable
--> 

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated