### PR TITLE
fix for testcase_29

### DIFF
--- a/HQSmokeTests/testPages/data/import_cases_page.py
+++ b/HQSmokeTests/testPages/data/import_cases_page.py
@@ -5,7 +5,6 @@ from selenium.webdriver.common.by import By
 
 from common_utilities.selenium.base_page import BasePage
 from common_utilities.generate_random_string import fetch_random_string
-from common_utilities.path_settings import PathSettings
 from HQSmokeTests.userInputs.user_inputs import UserData
 
 """"Contains test page elements and functions related to the Import Cases from Excel module"""
@@ -25,8 +24,8 @@ class ImportCasesPage(BasePage):
         self.file_new_name = "reassign_cases_" + str(fetch_random_string()) + ".xlsx"
 
         self.village_name_cell = "C2"
-        self.to_be_edited_file = os.path.abspath(os.path.join(PathSettings.BASE_DIR, "test_data/reassign_cases.xlsx"))
-        self.renamed_file = os.path.abspath(os.path.join(PathSettings.BASE_DIR, "test_data/" + self.file_new_name))
+        self.to_be_edited_file = os.path.abspath(os.path.join(UserData.USER_INPUT_BASE_DIR, "test_data/reassign_cases.xlsx"))
+        self.renamed_file = os.path.abspath(os.path.join(UserData.USER_INPUT_BASE_DIR, "test_data/" + self.file_new_name))
 
         self.import_cases_menu = (By.LINK_TEXT, "Import Cases from Excel")
         self.download_file = (By.XPATH, "(//span[@data-bind='text: upload_file_name'])[1]")

--- a/HQSmokeTests/userInputs/user_inputs.py
+++ b/HQSmokeTests/userInputs/user_inputs.py
@@ -1,8 +1,10 @@
 """"Contains test data that are used as user inputs across various areasn in CCHQ"""
+import os
 
 
 class UserData:
     """User Test Data"""
+    USER_INPUT_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
     # Pre-setup application and case names
     village_application = "Village Health"


### PR DESCRIPTION
## Summary
Fix for test case 29 reassign cases

## Description
After creating the common utilities, a path is changed in the reassign cases. Added that path in HQSmokeTest userData as it was specific to HQSmokeTest and did not add it in the common utilities.


### Link to Jira Ticket (if applicable)
<!--
Provide link to Jira ticket if applicable
--> 

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated