### PR TITLE
QA-4576 added wait for element steps for success messages in web_apps_page.py and change wait_to_click to js_click for show full menu

### DIFF
--- a/HQSmokeTests/testPages/home/home_page.py
+++ b/HQSmokeTests/testPages/home/home_page.py
@@ -92,7 +92,7 @@ class HomePage(BasePage):
 
     def open_menu(self, menu):
         if self.is_present(self.show_full_menu):
-            self.wait_to_click(self.show_full_menu)
+            self.js_click(self.show_full_menu)
         print(self.dashboard_link)
         self.driver.get(self.dashboard_link)
         self.wait_to_click(menu)

--- a/HQSmokeTests/testPages/webapps/web_apps_page.py
+++ b/HQSmokeTests/testPages/webapps/web_apps_page.py
@@ -69,6 +69,7 @@ class WebAppsPage(BasePage):
         self.wait_to_click(self.form_link)
         self.wait_to_clear_and_send_keys(self.form_case_name_input, self.case_name_created)
         self.js_click(self.form_submit_button)
+        self.wait_for_element(self.success_message)
         assert self.is_displayed(self.success_message), "Form not submitted"
         print("Form successfully submitted")
         self.driver.refresh()
@@ -82,6 +83,7 @@ class WebAppsPage(BasePage):
         self.wait_to_clear_and_send_keys(self.enter_value_area, self.text_value+Keys.TAB)
         self.js_click(self.form_submit_button)
         time.sleep(5)
+        self.wait_for_element(self.success_message)
         assert self.is_displayed(self.success_message), "Form not submitted"
         print("Form successfully submitted")
         return self.text_value
@@ -99,6 +101,7 @@ class WebAppsPage(BasePage):
         self.wait_to_clear_and_send_keys(self.update_value_area, self.random_value+Keys.TAB)
         self.js_click(self.form_submit_button)
         time.sleep(5)
+        self.wait_for_element(self.success_message)
         assert self.is_displayed(self.success_message), "Form not submitted"
         print("Form successfully submitted")
         # self.wait_to_click(self.show_full_menu_link)


### PR DESCRIPTION
## Summary
Added wait for element steps for success messages in web_apps_page.py and change wait_to_click to js_click for show full menu in home_page.py

## Description

Added wait for element steps for success messages in web_apps_page.py and change wait_to_click to js_click for show full menu in home_page.py

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-4576)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated