### PR TITLE
Added trigger to slack in case search failures

### DIFF
--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -130,6 +130,65 @@ jobs:
           attachments: ${{ github.workspace }}/report_${{ matrix.environment }}.html
           in_reply_to: ${{ fromJSON(steps.configure_email.outputs.result).reference }}
 
+
+      - name: Post to Slack channel on Failure
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        if: failure()
+        with:
+          payload: |
+            {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!"
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                            },
+                          {
+                                "type": "mrkdwn",
+                                "text": " "
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Status: *\n ${{ job.status }}  :x:"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
+                        },
+                        "accessory": {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "View on Github",
+                                "emoji": true
+                            },
+                            "value": "click_me_123",
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "action_id": "button-action",
+                            "style": "danger"
+                        }
+                    }
+                ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+
       - name: Archive test results
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary

Added trigger to slack in case search failures

## Description
The case search mails were getting lost in the dump of script result emails. This will trigger failures on slack channel #qa-gitactions like:

![image](https://user-images.githubusercontent.com/67914792/210606841-7922ffb6-2658-46f4-8732-3871c07fc7b6.png)

Here's the app created on slack to configure webhooks: https://api.slack.com/apps/A04HL5CHZMF/incoming-webhooks?success=1

### Link to Jira Ticket (if applicable)
[https://dimagi-dev.atlassian.net/browse/QAV2-4347 ](https://dimagi-dev.atlassian.net/browse/QAV2-4347)

## QA Checklist

- [x] Label(s) and Assignee added
- [x] PR sent for review
- [ ] Documentation (if applicable) added/updated
