### PR TITLE
Added slack failure alert triggers for HQ and API and updated WEBHOOK URLS

### DIFF
--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -185,7 +185,7 @@ jobs:
                 ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_USH }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -142,6 +142,62 @@ jobs:
           attachments: ${{ github.workspace }}/report_${{ matrix.environment }}.html
           in_reply_to: ${{ fromJSON(steps.configure_email.outputs.result).reference }}
 
+      - name: Post to Slack channel on Failure
+          id: slack
+          uses: slackapi/slack-github-action@v1.23.0
+          if: failure()
+          with:
+            payload: |
+              {
+                  "blocks": [
+                      {
+                          "type": "section",
+                          "text": {
+                              "type": "mrkdwn",
+                              "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!"
+                          }
+                      },
+                      {
+                          "type": "context",
+                          "elements": [
+                              {
+                                  "type": "mrkdwn",
+                                  "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                              },
+                            {
+                                  "type": "mrkdwn",
+                                  "text": " "
+                              },
+                              {
+                                  "type": "mrkdwn",
+                                  "text": "*Status: *\n ${{ job.status }}  :x:"
+                              }
+                          ]
+                      },
+                      {
+                          "type": "section",
+                          "text": {
+                              "type": "mrkdwn",
+                              "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
+                          },
+                          "accessory": {
+                              "type": "button",
+                              "text": {
+                                  "type": "plain_text",
+                                  "text": "View on Github",
+                                  "emoji": true
+                              },
+                              "value": "click_me_123",
+                              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                              "action_id": "button-action",
+                              "style": "danger"
+                          }
+                      }
+                  ]
+              }
+          env:
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: Archive test results
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -196,7 +196,8 @@ jobs:
                   ]
               }
           env:
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
+            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Archive test results
         if: ${{ success() || failure() }}

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -159,7 +159,8 @@ jobs:
                 ]
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Archive test results
       if: always()

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -105,6 +105,62 @@ jobs:
         attachments: /home/runner/work/dimagi-qa/dimagi-qa/report.html
         priority: normal
 
+    - name: Post to Slack channel on Failure
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        if: failure()
+        with:
+          payload: |
+            {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!"
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                            },
+                          {
+                                "type": "mrkdwn",
+                                "text": " "
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Status: *\n ${{ job.status }}  :x:"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
+                        },
+                        "accessory": {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "View on Github",
+                                "emoji": true
+                            },
+                            "value": "click_me_123",
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "action_id": "button-action",
+                            "style": "danger"
+                        }
+                    }
+                ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary

Trigger Failure Alerts on Slack Channels

## Description

- Added slack failure alert triggers for HQ and API on Slack channel #qa-smoke-script-results
- Added slack failure alert triggers for Casesearch on Slack channel #qa-ush-script-results
- Added webhook URLs separately for the both here https://api.slack.com/apps/A04HL5CHZMF/incoming-webhooks?success=1
- Added secrets SLACK_WEBHOOK_URL_USH and SLACK_WEBHOOK_URL_SMOKE for separate triggers

### Link to Jira Ticket (if applicable)
[https://dimagi-dev.atlassian.net/browse/QA-4347](https://dimagi-dev.atlassian.net/browse/QA-4347)

## QA Checklist

- [x] Label(s) and Assignee added
- [x] PR sent for review
- [ ] Documentation (if applicable) added/updated