### PR TITLE
Added Slack Failure triggers for HQ & API #Attempt2

### DIFF
--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -143,61 +143,61 @@ jobs:
           in_reply_to: ${{ fromJSON(steps.configure_email.outputs.result).reference }}
 
       - name: Post to Slack channel on Failure
-          id: slack
-          uses: slackapi/slack-github-action@v1.23.0
-          if: failure()
-          with:
-            payload: |
-              {
-                  "blocks": [
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!"
-                          }
-                      },
-                      {
-                          "type": "context",
-                          "elements": [
-                              {
-                                  "type": "mrkdwn",
-                                  "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                              },
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        if: failure()
+        with:
+          payload: |
+            {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!"
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
                             {
-                                  "type": "mrkdwn",
-                                  "text": " "
-                              },
-                              {
-                                  "type": "mrkdwn",
-                                  "text": "*Status: *\n ${{ job.status }}  :x:"
-                              }
-                          ]
-                      },
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
-                          },
-                          "accessory": {
-                              "type": "button",
-                              "text": {
-                                  "type": "plain_text",
-                                  "text": "View on Github",
-                                  "emoji": true
-                              },
-                              "value": "click_me_123",
-                              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                              "action_id": "button-action",
-                              "style": "danger"
-                          }
-                      }
-                  ]
-              }
-          env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
-            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                                "type": "mrkdwn",
+                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                            },
+                          {
+                                "type": "mrkdwn",
+                                "text": " "
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Status: *\n ${{ job.status }}  :x:"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
+                        },
+                        "accessory": {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "View on Github",
+                                "emoji": true
+                            },
+                            "value": "click_me_123",
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "action_id": "button-action",
+                            "style": "danger"
+                        }
+                    }
+                ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Archive test results
         if: ${{ success() || failure() }}

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -106,61 +106,61 @@ jobs:
         priority: normal
 
     - name: Post to Slack channel on Failure
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
-        if: failure()
-        with:
-          payload: |
-            {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
+      id: slack-api
+      uses: slackapi/slack-github-action@v1.23.0
+      if: failure()
+      with:
+        payload: |
+          {
+              "blocks": [
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!"
+                      }
+                  },
+                  {
+                      "type": "context",
+                      "elements": [
                           {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                              "type": "mrkdwn",
+                              "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                          },
+                        {
+                              "type": "mrkdwn",
+                              "text": " "
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": "*Status: *\n ${{ job.status }}  :x:"
+                          }
+                      ]
+                  },
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "Here's the corresponding worklow execution :arrow_right::arrow_right:"
+                      },
+                      "accessory": {
+                          "type": "button",
+                          "text": {
+                              "type": "plain_text",
+                              "text": "View on Github",
+                              "emoji": true
+                          },
+                          "value": "click_me_123",
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                          "action_id": "button-action",
+                          "style": "danger"
+                      }
+                  }
+              ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SMOKE }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Archive test results
       if: always()


### PR DESCRIPTION
## Summary

Trigger Failure Alerts on Slack Channels

## Description

- Added slack failure alert triggers for HQ and API on Slack channel #qa-smoke-script-results
- Added slack failure alert triggers for Casesearch on Slack channel #qa-ush-script-results
- Added webhook URLs separately for the both here https://api.slack.com/apps/A04HL5CHZMF/incoming-webhooks?success=1
- Added secrets SLACK_WEBHOOK_URL_USH and SLACK_WEBHOOK_URL_SMOKE for separate triggers

### Link to Jira Ticket (if applicable)
[https://dimagi-dev.atlassian.net/browse/QA-4347](https://dimagi-dev.atlassian.net/browse/QA-4347)

## QA Checklist

- [x] Label(s) and Assignee added
- [x] PR sent for review
- [ ] Documentation (if applicable) added/updated