### PR TITLE
QA-4891 removed conditions to send out success emails for hq smoke tests

### DIFF
--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -82,7 +82,7 @@ jobs:
           pytest -v --rootdir= HQSmokeTests/testCases -n 4 --dist=loadfile --reruns 1 --html=report_${{ matrix.environment }}.html
 
       - name: Set email vars
-        if: ${{ success() || failure() }}
+        if: ${{ failure() }}
         id: configure_email
         uses: actions/github-script@v6
         env:
@@ -127,7 +127,7 @@ jobs:
             }
 
       - name: Send Result Email
-        if: ${{ success() || failure() }}
+        if: ${{ failure() }}
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com


### PR DESCRIPTION
## Summary
updated hq yml file to stop success email alerts in gitaction jobs

## Description

updated hq yml file to stop success email alerts in gitaction jobs


### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-4891)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated