### PR TITLE
QA-4981 Fixes for test_case_29_import_cases, test_case_44_create_cond_alert and test_case_46_keyword_creation

### DIFF
--- a/HQSmokeTests/testCases/test_09_messaging.py
+++ b/HQSmokeTests/testCases/test_09_messaging.py
@@ -70,6 +70,7 @@ def test_case_46_keyword_creation(driver, settings):
     menu = HomePage(driver, settings)
     msg = MessagingPage(driver)
     menu.messaging_menu()
+    msg.remove_all_keywords()
     msg.add_keyword_trigger()
     msg.remove_keyword()
     msg.add_structured_keyword_trigger()

--- a/HQSmokeTests/testPages/android/android_screen.py
+++ b/HQSmokeTests/testPages/android/android_screen.py
@@ -14,7 +14,7 @@ class AndroidScreen:
             "browserstack.key": settings["bs_key"],
 
             # Set URL of the application under test
-            "app": "bs://05cbf4bab72569d22876e8fdc80c309b7d27d925",
+            "app": "bs://f6840d8d56c10228cd1f9f748801c7648d3540b8",
 
             # Specify device and os_version for testing
             "device": "Google Pixel 4 XL",

--- a/HQSmokeTests/testPages/data/import_cases_page.py
+++ b/HQSmokeTests/testPages/data/import_cases_page.py
@@ -10,18 +10,12 @@ from HQSmokeTests.userInputs.user_inputs import UserData
 """"Contains test page elements and functions related to the Import Cases from Excel module"""
 
 
-def edit_spreadsheet(edited_file, cell, renamed_file):
-    workbook = load_workbook(filename=edited_file)
-    sheet = workbook.active
-    sheet[cell] = fetch_random_string()
-    workbook.save(filename=renamed_file)
-
-
 class ImportCasesPage(BasePage):
 
     def __init__(self, driver):
         super().__init__(driver)
         self.file_new_name = "reassign_cases_" + str(fetch_random_string()) + ".xlsx"
+        self.sheet_name = "reassign_cases_" + str(fetch_random_string())
 
         self.village_name_cell = "C2"
         self.to_be_edited_file = os.path.abspath(os.path.join(UserData.USER_INPUT_BASE_DIR, "test_data/reassign_cases.xlsx"))
@@ -37,7 +31,7 @@ class ImportCasesPage(BasePage):
 
     def replace_property_and_upload(self):
         self.wait_to_click(self.import_cases_menu)
-        edit_spreadsheet(self.to_be_edited_file, self.village_name_cell, self.renamed_file)
+        self.edit_spreadsheet(self.to_be_edited_file, self.village_name_cell, self.renamed_file, self.sheet_name)
         self.wait_to_clear_and_send_keys(self.choose_file, self.renamed_file)
         self.wait_to_click(self.next_step)
         self.is_visible_and_displayed(self.case_type)
@@ -46,3 +40,10 @@ class ImportCasesPage(BasePage):
         self.wait_to_click(self.next_step)
         print("Imported case!")
         assert self.is_visible_and_displayed(self.success), "Waitinng to start import. Celery might have a high queue."
+
+    def edit_spreadsheet(self, edited_file, cell, renamed_file, sheet_name):
+        workbook = load_workbook(filename=edited_file)
+        sheet = workbook.active
+        sheet[cell] = fetch_random_string()
+        sheet.title = sheet_name
+        workbook.save(filename=renamed_file)

--- a/HQSmokeTests/testPages/messaging/messaging_page.py
+++ b/HQSmokeTests/testPages/messaging/messaging_page.py
@@ -63,6 +63,8 @@ class MessagingPage(BasePage):
         self.continue_button_rule_tab = (By.XPATH, "//button[@data-bind='click: handleRuleNavContinue, enable: ruleTabValid']")
         self.cond_alert_created = (By.XPATH, "//a[text()='" + str(self.cond_alert_name_input) + "']")
         self.restart_rule_button = (By.XPATH, "//td[./a[text()='" + str(self.cond_alert_name_input) + "']]//following-sibling::td/div/button[contains(@data-bind,'restart')]")
+        self.restart_rule_button_none = (By.XPATH, "//td[./a[text()='" + str(
+            self.cond_alert_name_input) + "']]//following-sibling::td/div[@style='display: none;']/button[contains(@data-bind,'restart')]")
         self.empty_table_alert = (By.XPATH, "//div[contains(@data-bind, 'emptyTable()')][contains(.,'There are no alerts to display')]")
         self.select_recipient_type = (By.XPATH, "//ul[@id='select2-id_schedule-recipient_types-results']/li[.='Users']")
         self.alert_type = (By.XPATH, "//select[@name='schedule-content']")
@@ -133,6 +135,7 @@ class MessagingPage(BasePage):
         self.keywords_list = (By.XPATH, "//td[.//span/a[contains(.,'KEYWORD_')]]//following-sibling::td/button")
         self.delete_confirm_button = (
         By.XPATH, "//td[.//span/a[contains(.,'KEYWORD_')]]//following::a[@class='btn btn-danger delete-item-confirm'][1]")
+        self.page_empty = (By.ID, "pagination-empty-notification")
 
 
     def open_dashboard_page(self):
@@ -208,7 +211,10 @@ class MessagingPage(BasePage):
         print("Sleeping till the alert processing completes")
         time.sleep(20)
         self.driver.refresh()
-        if self.is_present(self.restart_rule_button):
+        if self.is_present(self.restart_rule_button_none):
+            print("Restart is not required.")
+
+        else:
             self.js_click(self.restart_rule_button)
             self.accept_pop_up()
             time.sleep(5)
@@ -216,8 +222,6 @@ class MessagingPage(BasePage):
             print("Sleeping till the alert processing completes")
             time.sleep(20)
             self.driver.refresh()
-        else:
-            print("Restart is not required.")
         self.wait_for_element(self.search_box)
         self.wait_to_click(self.search_box)
         assert self.is_displayed(self.cond_alert_created), "Conditional Alert not created successfully!"
@@ -366,29 +370,32 @@ class MessagingPage(BasePage):
 
     def remove_all_keywords(self):
         self.wait_to_click(self.keywords)
-        self.select_by_value(self.page_limit, "50")
-        time.sleep(3)
-        list = self.find_elements(self.keywords_list)
-        confirm_button_list = self.find_elements(self.delete_confirm_button)
-        print("List Count: ", len(list))
-        if len(list) > 0:
-            for i in range(len(list))[::-1]:
-                list[i].click()
-                time.sleep(1)
-                confirm_button_list[i].click()
-                time.sleep(1)
-                list = self.find_elements(self.keywords_list)
-                confirm_button_list = self.find_elements(self.delete_confirm_button)
-                print("Updated List Count: ", len(list))
-            self.driver.refresh()
-            time.sleep(5)
-            list = self.find_elements(self.keywords_list)
-            if len(list) == 0:
-                print("All test keywords deleted")
-            else:
-                print("All test keywords not deleted")
+        if self.is_present_and_displayed(self.page_empty, 10):
+            print("No keywords present")
         else:
-            print("No test keywords present")
+            self.select_by_value(self.page_limit, "50")
+            time.sleep(3)
+            list = self.find_elements(self.keywords_list)
+            confirm_button_list = self.find_elements(self.delete_confirm_button)
+            print("List Count: ", len(list))
+            if len(list) > 0:
+                for i in range(len(list))[::-1]:
+                    list[i].click()
+                    time.sleep(1)
+                    confirm_button_list[i].click()
+                    time.sleep(1)
+                    list = self.find_elements(self.keywords_list)
+                    confirm_button_list = self.find_elements(self.delete_confirm_button)
+                    print("Updated List Count: ", len(list))
+                self.driver.refresh()
+                time.sleep(5)
+                list = self.find_elements(self.keywords_list)
+                if len(list) == 0:
+                    print("All test keywords deleted")
+                else:
+                    print("All test keywords not deleted")
+            else:
+                print("No test keywords present")
 
     def remove_cond_alert(self):
         self.wait_and_sleep_to_click(self.cond_alerts)

--- a/HQSmokeTests/testPages/messaging/messaging_page.py
+++ b/HQSmokeTests/testPages/messaging/messaging_page.py
@@ -62,6 +62,8 @@ class MessagingPage(BasePage):
         self.case_property_input = (By.XPATH, "//input[@class='select2-search__field']")
         self.continue_button_rule_tab = (By.XPATH, "//button[@data-bind='click: handleRuleNavContinue, enable: ruleTabValid']")
         self.cond_alert_created = (By.XPATH, "//a[text()='" + str(self.cond_alert_name_input) + "']")
+        self.restart_rule_button = (By.XPATH, "//td[./a[text()='" + str(self.cond_alert_name_input) + "']]//following-sibling::td/div/button[contains(@data-bind,'restart')]")
+        self.empty_table_alert = (By.XPATH, "//div[contains(@data-bind, 'emptyTable()')][contains(.,'There are no alerts to display')]")
         self.select_recipient_type = (By.XPATH, "//ul[@id='select2-id_schedule-recipient_types-results']/li[.='Users']")
         self.alert_type = (By.XPATH, "//select[@name='schedule-content']")
         self.user_recipients_results = (By.XPATH, "//ul[@id='select2-id_schedule-user_recipients-results']/li[.='"+ UserData.app_login +"']")
@@ -87,10 +89,10 @@ class MessagingPage(BasePage):
         self.keyword_survey = (By.XPATH, "(//span[@class='select2-selection select2-selection--single'])[1]")
         self.survey_option_select = (By.XPATH, "(//li[@class='select2-results__option select2-results__option--selectable'])[1]")
         self.structured_keyword_created = (By.XPATH, "//a[text()='" + self.struct_keyword_name_input + "']")
-        self.delete_keyword = (By.XPATH, self.keyword_created_xpath + "//following::a[@class='btn btn-danger'][1]")
-        self.delete_structured_keyword = (By.XPATH, "//a[text()='" + self.struct_keyword_name_input + "']//following::a[@class='btn btn-danger'][1]")
-        self.confirm_delete_keyword = (By.XPATH, self.keyword_created_xpath + "//following::a[@class='btn btn-danger delete-item-confirm'][1]")
-        self.confirm_delete_structured_keyword = (By.XPATH, "//a[text()='" + self.struct_keyword_name_input + "']//following::a[@class='btn btn-danger delete-item-confirm'][1]")
+        self.delete_keyword = (By.XPATH, self.keyword_created_xpath + "//following::*[@class='btn btn-danger'][1]")
+        self.delete_structured_keyword = (By.XPATH, "//a[text()='" + self.struct_keyword_name_input + "']//following::*[@class='btn btn-danger'][1]")
+        self.confirm_delete_keyword = (By.XPATH, self.keyword_created_xpath + "//following::*[@class='btn btn-danger delete-item-confirm'][1]")
+        self.confirm_delete_structured_keyword = (By.XPATH, "//a[text()='" + self.struct_keyword_name_input + "']//following::*[@class='btn btn-danger delete-item-confirm'][1]")
         # Chat
         self.chat = (By.LINK_TEXT, "Chat")
         self.contact_table = (By.ID, "contact_list")
@@ -127,6 +129,11 @@ class MessagingPage(BasePage):
         self.subscription_elements_id = (By.ID, "subscriptionSummary")
         self.project_settings_menu = (By.LINK_TEXT, "Project Settings")
         self.project_settings_elements = (By.XPATH, "//form[@class='form form-horizontal']")
+        self.page_limit = (By.XPATH, "//select[@id='pagination-limit']")
+        self.keywords_list = (By.XPATH, "//td[.//span/a[contains(.,'KEYWORD_')]]//following-sibling::td/button")
+        self.delete_confirm_button = (
+        By.XPATH, "//td[.//span/a[contains(.,'KEYWORD_')]]//following::a[@class='btn btn-danger delete-item-confirm'][1]")
+
 
     def open_dashboard_page(self):
         assert self.is_displayed(self.dashboard_elements), "Dashboatd  didn't load successfully!"
@@ -175,6 +182,7 @@ class MessagingPage(BasePage):
 
     def create_cond_alert(self):
         self.wait_to_click(self.cond_alerts)
+        self.remove_alert_with_same_name(self.cond_alert_name_input)
         self.wait_to_click(self.add_cond_alert)
         self.send_keys(self.cond_alert_name, self.cond_alert_name_input)
         self.wait_to_click(self.continue_button_basic_tab)
@@ -200,6 +208,16 @@ class MessagingPage(BasePage):
         print("Sleeping till the alert processing completes")
         time.sleep(20)
         self.driver.refresh()
+        if self.is_present(self.restart_rule_button):
+            self.js_click(self.restart_rule_button)
+            self.accept_pop_up()
+            time.sleep(5)
+            self.accept_pop_up()
+            print("Sleeping till the alert processing completes")
+            time.sleep(20)
+            self.driver.refresh()
+        else:
+            print("Restart is not required.")
         self.wait_for_element(self.search_box)
         self.wait_to_click(self.search_box)
         assert self.is_displayed(self.cond_alert_created), "Conditional Alert not created successfully!"
@@ -228,6 +246,9 @@ class MessagingPage(BasePage):
         self.send_keys(self.keyword_description, self.keyword_name_input)
         self.send_keys(self.keyword_message, "Test Message: " + self.keyword_name_input)
         self.click(self.send_message)
+        time.sleep(2)
+        self.select_by_value(self.page_limit, "50")
+        time.sleep(3)
         assert self.is_visible_and_displayed(self.keyword_created), "Keyword not created successfully!"
         print("Keyword created successfully!")
 
@@ -240,6 +261,9 @@ class MessagingPage(BasePage):
         self.wait_to_click(self.survey_option_select)
         self.send_keys(self.keyword_message, "Test Message" + self.struct_keyword_name_input)
         self.wait_to_click(self.send_message)
+        time.sleep(2)
+        self.select_by_value(self.page_limit, "50")
+        time.sleep(3)
         assert self.is_visible_and_displayed(self.structured_keyword_created), "Structured keyword not created successfully!"
         print("Structured keyword created successfully!")
 
@@ -326,6 +350,7 @@ class MessagingPage(BasePage):
             assert not isPresent
             print("Keyword removed successfully!")
 
+
     def remove_structured_keyword(self):
         self.wait_to_click(self.keywords)
         self.wait_to_click(self.delete_structured_keyword)
@@ -338,6 +363,32 @@ class MessagingPage(BasePage):
         if not isPresent:
             assert not isPresent
             print("Structured keyword removed successfully!")
+
+    def remove_all_keywords(self):
+        self.wait_to_click(self.keywords)
+        self.select_by_value(self.page_limit, "50")
+        time.sleep(3)
+        list = self.find_elements(self.keywords_list)
+        confirm_button_list = self.find_elements(self.delete_confirm_button)
+        print("List Count: ", len(list))
+        if len(list) > 0:
+            for i in range(len(list))[::-1]:
+                list[i].click()
+                time.sleep(1)
+                confirm_button_list[i].click()
+                time.sleep(1)
+                list = self.find_elements(self.keywords_list)
+                confirm_button_list = self.find_elements(self.delete_confirm_button)
+                print("Updated List Count: ", len(list))
+            self.driver.refresh()
+            time.sleep(5)
+            list = self.find_elements(self.keywords_list)
+            if len(list) == 0:
+                print("All test keywords deleted")
+            else:
+                print("All test keywords not deleted")
+        else:
+            print("No test keywords present")
 
     def remove_cond_alert(self):
         self.wait_and_sleep_to_click(self.cond_alerts)
@@ -360,6 +411,31 @@ class MessagingPage(BasePage):
             isPresent = False
         assert not isPresent
         print("Cond Alert removed successfully!")
+
+    def remove_alert_with_same_name(self, alert_name):
+        self.wait_to_clear_and_send_keys(self.search_box, alert_name)
+        self.wait_and_sleep_to_click(self.search_box)
+        time.sleep(5)
+        if self.is_present_and_displayed(self.empty_table_alert):
+            print("No alert created with the same name")
+        else:
+            self.wait_to_click(self.delete_cond_alert)
+            try:
+                obj = self.driver.switch_to.alert
+                obj.accept()
+            except NoAlertPresentException:
+                raise AssertionError("Celery down")
+            try:
+                time.sleep(2)
+                self.driver.refresh()
+                self.wait_to_clear_and_send_keys(self.search_box, self.cond_alert_name_input)
+                self.wait_and_sleep_to_click(self.search_box)
+                isPresent = self.is_displayed(self.cond_alert_created)
+            except NoSuchElementException:
+                isPresent = False
+            assert not isPresent
+            print("Cond Alert removed successfully!")
+
 
     def msg_trans_download(self):
         self.wait_to_click(self.languages)

--- a/HQSmokeTests/testPages/messaging/messaging_page.py
+++ b/HQSmokeTests/testPages/messaging/messaging_page.py
@@ -370,9 +370,10 @@ class MessagingPage(BasePage):
 
     def remove_all_keywords(self):
         self.wait_to_click(self.keywords)
-        if self.is_present_and_displayed(self.page_empty, 10):
+        time.sleep(3)
+        if self.is_present(self.page_empty):
             print("No keywords present")
-        else:
+        elif self.is_present(self.page_limit):
             self.select_by_value(self.page_limit, "50")
             time.sleep(3)
             list = self.find_elements(self.keywords_list)
@@ -394,8 +395,8 @@ class MessagingPage(BasePage):
                     print("All test keywords deleted")
                 else:
                     print("All test keywords not deleted")
-            else:
-                print("No test keywords present")
+        else:
+            print("No test keywords present")
 
     def remove_cond_alert(self):
         self.wait_and_sleep_to_click(self.cond_alerts)

--- a/HQSmokeTests/testPages/users/mobile_workers_page.py
+++ b/HQSmokeTests/testPages/users/mobile_workers_page.py
@@ -360,7 +360,7 @@ class MobileWorkerPage(BasePage):
             time.sleep(5)
             self.send_keys(self.choose_file, str(file_that_was_downloaded))
             self.wait_and_sleep_to_click(self.upload)
-            self.wait_for_element(self.successfully_uploaded, 50)
+            self.wait_for_element(self.successfully_uploaded, 150)
         except (TimeoutException, NoSuchElementException):
             print("TIMEOUT ERROR: Could not upload file")
         assert self.is_present_and_displayed(self.import_complete), "Upload Not Completed! Taking Longer to process.."


### PR DESCRIPTION
## Summary
Fixes for test_case_29_import_cases, test_case_44_create_cond_alert, test_case_46_keyword_creation and test_case_38_create_new_build_deploy_to_mobile

## Description

Fixes for the below testcase:

- test_case_29_import_cases - updated testcase according to the changes of [ticket](https://dimagi-dev.atlassian.net/browse/QA-4954)
- test_case_44_create_cond_alert - added the functionality to Restart Rule in case the processing stopped, also remove alert with same name if already created 
- test_case_46_keyword_creation - added functionality to remove all test keywords before the actual workflow, also updated links of delete and confirm delete button. Locators are different in both staging and prod, updated as a generic locator.
- test_case_38_create_new_build_deploy_to_mobile- updated browserstack app url

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-4981)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated