### PR TITLE
QA-5160 added testcase for login logout tracking api

### DIFF
--- a/RequestAPI/testCases/test_10_misc.py
+++ b/RequestAPI/testCases/test_10_misc.py
@@ -24,3 +24,9 @@ def test_case_33_user_domain_list_api(settings):
     uri = settings["url"] + UserData.post_domain_url
     mw = MiscellaneousMethods(settings)
     mw.get_user_domain_list_api(uri, settings['login_user'], settings['login_pass'])
+
+@pytest.mark.xfail("QA-5164")
+def test_case_39_login_logout_tracking_api(settings):
+    uri = settings["url"] + UserData.login_logout_tracking
+    mw = MiscellaneousMethods(settings)
+    mw.get_login_logout_track(uri, settings['login_user'], settings['login_pass'])

--- a/RequestAPI/testMethods/miscellaneous_methods.py
+++ b/RequestAPI/testMethods/miscellaneous_methods.py
@@ -34,3 +34,8 @@ class MiscellaneousMethods(Base):
         result = self.get_api(URL, login_user, login_pass, self.headers)
         print(result.status_code)
 
+    def get_login_logout_track(self, uri, login_user, login_pass):
+        URL = uri+'action_times'
+        result = self.get_api(URL, login_user, login_pass, self.headers)
+        print(result.status_code)
+

--- a/RequestAPI/userInputs/user_inputs.py
+++ b/RequestAPI/userInputs/user_inputs.py
@@ -7,4 +7,5 @@ class UserData:
     domain = 'a/api-tests/'
     domain2 = 'a/qateam/'
     post_domain_url = 'api/v0.5/'
+    login_logout_tracking = 'a/qateam/api/v0.5/'
 


### PR DESCRIPTION
## Summary
Added a testcase for Login/Logout tracking API

## Description
Added a testcase for Login/Logout tracking API. Currently it is failing due to [ticket](https://dimagi-dev.atlassian.net/browse/QA-5164), so marked as xfail.

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-5160)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated