### PR TITLE
QA-5441 fix for android test failure and intermittent Mobile Worker testcase failures

### DIFF
--- a/HQSmokeTests/testCases/test_02_users.py
+++ b/HQSmokeTests/testCases/test_02_users.py
@@ -15,6 +15,40 @@ group_id = dict()
 group_id["user"] = "username_"+fetch_random_string()
 group_id["user_new"] = "username_"+fetch_random_string()+"_new"
 
+
+@pytest.mark.user
+@pytest.mark.groups
+@pytest.mark.user_profiles
+@pytest.mark.user_fields
+@pytest.mark.mobileWorker
+def test_initial_cleanup_items_in_users_menu(driver, settings):
+    clean = MobileWorkerPage(driver)
+    clean2 = GroupPage(driver)
+
+    menu = HomePage(driver, settings)
+    menu.users_menu()
+    clean.delete_bulk_users()
+
+    menu.users_menu()
+    clean.mobile_worker_menu()
+    clean.edit_user_field()
+    clean.click_profile()
+    clean.delete_profile()
+    print("Removed all test profiles")
+
+    menu.users_menu()
+    clean.mobile_worker_menu()
+    clean.edit_user_field()
+    clean.delete_test_user_field()
+    print("Deleted the user field")
+
+    clean.mobile_worker_menu()
+    clean2.click_group_menu()
+    clean2.delete_test_groups()
+    print("Deleted the group")
+
+
+
 @pytest.mark.user
 @pytest.mark.mobileWorker
 @pytest.mark.run(order=0)
@@ -118,7 +152,7 @@ def test_case_04_reactivate_user(driver, settings):
 @pytest.mark.user_profiles
 @pytest.mark.user_fields
 @pytest.mark.mobileWorker
-def test_cleanup_items_in_users_menu(driver, settings):
+def test_aftertest_cleanup_items_in_users_menu(driver, settings):
     clean = MobileWorkerPage(driver)
     clean2 = GroupPage(driver)
 
@@ -170,7 +204,6 @@ def test_case_54_add_custom_user_data_profile_to_mobile_worker(driver, settings)
     menu.users_menu()
     create.mobile_worker_menu()
     create.delete_bulk_users()
-    # create.select_and_delete_mobile_worker(group_id["user_new"])
     menu.users_menu()
     create.mobile_worker_menu()
     create.edit_user_field()

--- a/HQSmokeTests/testPages/android/android_screen.py
+++ b/HQSmokeTests/testPages/android/android_screen.py
@@ -1,7 +1,11 @@
 from appium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+
 from HQSmokeTests.userInputs.user_inputs import UserData
 from appium.options.android import UiAutomator2Options
 from appium.webdriver.common.appiumby import AppiumBy
+from selenium.webdriver.support import expected_conditions as ec
 import time
 
 """"Contains test page elements and functions related to the app installation and form submission on mobile"""
@@ -20,6 +24,7 @@ class AndroidScreen:
             "app": "bs://eaf01d03c4c260f5a40dc5a1ee650e338706d97b",
 
             "autoGrantPermissions": "true",
+            "newCommandTimeout": 200,
 
             # Set other BrowserStack capabilities
             'bstack:options': {
@@ -40,6 +45,7 @@ class AndroidScreen:
             "http://hub-cloud.browserstack.com/wd/hub",
             options=self.options
         )
+        self.driver.implicitly_wait(15)
 
         # Locator
         self.enter_code = "//android.widget.TextView[@text='Enter Code']"
@@ -76,26 +82,26 @@ class AndroidScreen:
         self.driver.find_element(by=AppiumBy.XPATH, value=self.enter_code).click()
         self.driver.find_element(by=AppiumBy.ID, value=self.profile_code).send_keys(code)
         self.driver.find_element(by=AppiumBy.ID, value=self.start_install).click()
-        time.sleep(2)
+        time.sleep(3)
         self.driver.find_element(by=AppiumBy.XPATH, value=self.install).click()
         time.sleep(15)
         self.driver.find_element(by=AppiumBy.ID, value=self.username).send_keys(UserData.app_login)
         self.driver.find_element(by=AppiumBy.ID, value=self.password).send_keys(UserData.app_password)
         self.driver.find_element(by=AppiumBy.ID, value=self.login).click()
-        time.sleep(20)
+        time.sleep(50)
         self.driver.find_element(by=AppiumBy.XPATH, value=self.start_button).click()
-        time.sleep(2)
+        time.sleep(3)
         self.driver.find_element(by=AppiumBy.XPATH, value=self.case_list).click()
-        time.sleep(2)
+        time.sleep(3)
         self.driver.find_element(by=AppiumBy.XPATH, value=self.form).click()
-        time.sleep(2)
+        time.sleep(3)
         assert self.driver.find_element(by=AppiumBy.XPATH, value="//android.widget.TextView[@text='Add Text "+random_text+"']").is_displayed()
         self.driver.find_element(by=AppiumBy.XPATH, value=self.text_field).send_keys(random_text)
         self.driver.find_element(by=AppiumBy.XPATH, value=self.submit_button).click()
-        time.sleep(5)
+        time.sleep(10)
         assert self.driver.find_element(by=AppiumBy.XPATH, value="//android.widget.TextView[@text='1 form sent to server!']").is_displayed()
         self.driver.find_element(by=AppiumBy.XPATH, value=self.sync_button).click()
-        time.sleep(2)
+        time.sleep(3)
 
     def close_android_driver(self):
         self.driver.quit()


### PR DESCRIPTION
## Summary
Fix for android test failure and intermittent Mobile Worker testcase failures

## Description
Android test fix: updated locator, step and sleep time for android testcase,
Mobile Worker fix: added another cleanup testcase before start of the test_02_users.py module tests

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-5441)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated