### PR TITLE
QA-5566 updated steps for getting app code

### DIFF
--- a/HQSmokeTests/testPages/applications/application_page.py
+++ b/HQSmokeTests/testPages/applications/application_page.py
@@ -91,6 +91,7 @@ class ApplicationPage(BasePage):
         self.delete_form_confirm = (By.XPATH, "//div[./p[./strong[contains(text(),'Android')]]]/following-sibling::div[button]//i[@class='fa fa-trash']")
         self.code = (By.XPATH, "//code")
         self.close = (By.XPATH, "//div[.//code]/following-sibling::div//a[contains(text(),'Close')]")
+        self.enter_app_code_link = (By.LINK_TEXT, "Enter App Code")
 
     def create_new_application(self):
         self.wait_to_click(self.applications_menu_id)
@@ -212,6 +213,7 @@ class ApplicationPage(BasePage):
         print("Sleeping for the installation code to generate")
         time.sleep(10)
         self.wait_to_click(self.publish_button)
+        self.wait_to_click(self.enter_app_code_link)
         code_text = self.wait_to_get_text(self.code)
         self.wait_to_click(self.close)
         # self.wait_to_click(self.delete_form)


### PR DESCRIPTION
## Summary
Earlier, on clicking the Publish button the App Code was visible but now we have to click on a link “Enter App Code“. Added steps for the same.

## Description
Earlier, on clicking the Publish button the App Code was visible but now we have to click on a link “Enter App Code“. Added steps for the same.

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-5566)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated