### PR TITLE
wait after performing search even if an exception occurs

### DIFF
--- a/LocustScripts/commcarehq-bed-track.py
+++ b/LocustScripts/commcarehq-bed-track.py
@@ -150,11 +150,12 @@ class WorkloadModelSteps(SequentialTaskSet):
                         i) + " is " + str(total_time) + " seconds.")
                 logging.info(
                     "user: " + self.user.username + "; mobile worker: " + self.user.login_as + "; request: navigate_menu")
-                logging.info("mobile worker: " + self.user.login_as + " Sleeping for-->" + str(rng))
-                time.sleep(rng)
             except Exception as e:
                 logging.info(
                     "user: " + self.user.username + "; mobile worker: " + self.user.login_as + "; request: navigate_menu; exception: " + str(e))
+
+            logging.info("mobile worker: " + self.user.login_as + " Sleeping for-->" + str(rng))
+            time.sleep(rng)
 
         @task
         def stop(self):


### PR DESCRIPTION
## Summary
As is, if an exception occurs within `perform_a_search`, the wait time is skipped and the next iteration of the `for loop` is executed immediately. This change waits between searches even if there is an exception.

## Description
see Summary

### Link to Jira Ticket (if applicable)


## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated

