### PR TITLE
QA-5310 updated slack notification for all testsuits

### DIFF
--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -188,7 +188,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -245,7 +245,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -91,7 +91,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job_id }}
+          name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
-          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html
           retention-days: 2
 
       - name: Fetch artifact ID
@@ -304,17 +304,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View Test Summary",
+            							"text": "Click to Download",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -86,6 +86,19 @@ jobs:
             echo "::set-output name=${line%=*}::${line#*=}"
           done < bha_test_counts_${{ matrix.environment }}.txt
 
+      - name: Archive test results
+        id: artifact-upload-step
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-reports-${{ github.job }}
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          retention-days: 2
+
+      - name: Fetch artifact ID
+        run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+
+
       - name: Set email vars
         if: ${{ success() || failure() }}
         id: configure_email
@@ -232,7 +245,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "danger"
             					}
@@ -301,7 +314,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}
@@ -313,10 +326,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: Archive test results
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-result-reports-${{ matrix.environment }}
-          path: ${{ github.workspace }}/report_${{ matrix.environment }}.html

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -304,17 +304,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "Click to Downlaod",
+            							"text": "View Test Summary",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -91,7 +91,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job }}
+          name: test-result-reports-${{ github.job_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -183,51 +183,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#FF0000",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :x:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "danger"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
@@ -240,51 +252,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "primary"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#36a64f",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "primary"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -16,15 +16,21 @@ on:
         options:
           - staging
           - production
+  schedule:
+    - cron: '30 7 * * 1-5'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -70,6 +76,15 @@ jobs:
           echo "NOW=$(date +'%m-%d %H:%M')" >> $GITHUB_ENV
           echo ${{env.NOW}}
           pytest -v "./USH_Apps/CO_BHA/test_cases" --dist=loadfile --reruns 1 --html=report_${{ matrix.environment }}.html
+
+      - name: Parse test counts
+        id: parse_counts
+        if: always()
+        run: |
+          # Extract variables from the api_test_counts.txt file
+          while IFS= read -r line; do
+            echo "::set-output name=${line%=*}::${line#*=}"
+          done < bha_test_counts_${{ matrix.environment }}.txt
 
       - name: Set email vars
         if: ${{ success() || failure() }}
@@ -173,7 +188,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -230,7 +245,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Hey :bye_boo: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/bha-tests.yml
+++ b/.github/workflows/bha-tests.yml
@@ -235,13 +235,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
@@ -304,13 +304,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -182,51 +182,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#ff0000",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Salut 👋 \n*${{ github.workflow }}* were just triggered! \n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :x:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "danger"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
@@ -240,51 +252,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "primary"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#36a64f",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!\n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "primary"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -187,7 +187,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -245,7 +245,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -83,6 +83,18 @@ jobs:
             echo "::set-output name=${line%=*}::${line#*=}"
           done < sscs_test_counts_${{ matrix.environment }}.txt
 
+      - name: Archive test results
+        id: artifact-upload-step
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-reports-${{ github.job }}
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          retention-days: 2
+
+      - name: Fetch artifact ID
+        run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+
 
       - name: Set email vars
         if: ${{ success() || failure() }}
@@ -231,7 +243,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "danger"
             					}
@@ -301,7 +313,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}
@@ -313,11 +325,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
-      - name: Archive test results
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-result-reports-${{ matrix.environment }}
-          path: ${{ github.workspace }}/report_${{ matrix.environment }}.html

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -16,15 +16,21 @@ on:
         options:
           - staging
           - production
+schedule:
+    - cron: '0 8 * * 1-5'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -67,6 +73,16 @@ jobs:
           echo "NOW=$(date +'%m-%d %H:%M')" >> $GITHUB_ENV
           echo ${{env.NOW}}
           pytest -v "./Features/CaseSearch/test_cases" --dist=loadfile --html=report_${{ matrix.environment }}.html
+
+      - name: Parse test counts
+        id: parse_counts
+        if: always()
+        run: |
+          # Extract variables from the hqsmoke_test_counts.txt file
+          while IFS= read -r line; do
+            echo "::set-output name=${line%=*}::${line#*=}"
+          done < sscs_test_counts_${{ matrix.environment }}.txt
+
 
       - name: Set email vars
         if: ${{ success() || failure() }}
@@ -171,7 +187,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -229,7 +245,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Salut 👋 \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -303,17 +303,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding workflow summary :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "Click to Downlaod",
+            							"text": "View Test Summary",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job }}
+          name: test-result-reports-${{ github.job_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -16,7 +16,7 @@ on:
         options:
           - staging
           - production
-schedule:
+  schedule:
     - cron: '0 8 * * 1-5'
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job_id }}
+          name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
-          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html
           retention-days: 2
 
       - name: Fetch artifact ID
@@ -303,17 +303,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow summary :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View Test Summary",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/case-search-tests.yml
+++ b/.github/workflows/case-search-tests.yml
@@ -233,13 +233,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
@@ -303,13 +303,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
-          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html
           retention-days: 2
 
       - name: Fetch artifact ID
@@ -302,17 +302,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View Test Summary",
+            							"text": "Click to Download",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -302,17 +302,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "Click to Downlaod",
+            							"text": "View Test Summary",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -181,51 +181,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#ff0000",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :x:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "danger"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
@@ -238,51 +250,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "primary"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#36a64f",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "primary"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -84,6 +84,19 @@ jobs:
             echo "::set-output name=${line%=*}::${line#*=}"
           done < cs_test_counts_${{ matrix.environment }}.txt
 
+      - name: Archive test results
+        id: artifact-upload-step
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-reports-${{ github.job }}
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          retention-days: 2
+
+      - name: Fetch artifact ID
+        run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+
+
       - name: Set email vars
         if: ${{ success() || failure() }}
         id: configure_email
@@ -230,7 +243,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "danger"
             					}
@@ -299,7 +312,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}
@@ -312,9 +325,3 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-      - name: Archive test results
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-result-reports-${{ matrix.environment }}
-          path: ${{ github.workspace }}/report_${{ matrix.environment }}.html

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -16,7 +16,7 @@ on:
         options:
           - staging
           - production
-schedule:
+  schedule:
     - cron: '0 8 * * 1-5'
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job }}
+          name: test-result-reports-${{ github.job_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job_id }}
+          name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -16,15 +16,21 @@ on:
         options:
           - staging
           - production
+schedule:
+    - cron: '0 8 * * 1-5'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -68,6 +74,15 @@ jobs:
           echo "NOW=$(date +'%m-%d %H:%M')" >> $GITHUB_ENV
           echo ${{env.NOW}}
           pytest -v "./Features/SplitScreenCaseSearch/test_cases" --dist=loadfile --html=report_${{ matrix.environment }}.html
+
+      - name: Parse test counts
+        id: parse_counts
+        if: always()
+        run: |
+          # Extract variables from the hqsmoke_test_counts.txt file
+          while IFS= read -r line; do
+            echo "::set-output name=${line%=*}::${line#*=}"
+          done < cs_test_counts_${{ matrix.environment }}.txt
 
       - name: Set email vars
         if: ${{ success() || failure() }}
@@ -171,7 +186,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -228,7 +243,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -186,7 +186,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -243,7 +243,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Hey there! :alien-wave::alien-wave: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/casesearch-split-screen-tests.yml
+++ b/.github/workflows/casesearch-split-screen-tests.yml
@@ -233,13 +233,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
@@ -302,13 +302,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job }}
+          name: test-result-reports-${{ github.job_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -263,7 +263,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n\n*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -241,7 +241,7 @@ jobs:
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html",
+                            "url": "${{ github.workspace }}/report_${{ matrix.environment }}.html",
                             "action_id": "button-action",
                             "style": "danger"
                         }
@@ -298,7 +298,7 @@ jobs:
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html"
+                            "url": "${{ github.workspace }}/report_${{ matrix.environment }}.html",
                             "action_id": "button-action",
                             "style": "primary"
                         }

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -201,51 +201,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#FF0000",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :x:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+                                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "danger"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
@@ -257,50 +269,62 @@ jobs:
         if: ${{ steps.configure_slack.outputs.result != ' ' && success() }}
         with:
           payload: |
-            {
-                "blocks": [
+             {
+                "attachments": [
                     {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
+                        "color": "#36a64f",
+                        "blocks": [
                             {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n"
+                                }
                             },
                             {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+                                 "type": "section",
+                                 "text": {
+                                     "type": "mrkdwn",
+                                     "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                                }
+                            },
+                            {
+                                "type": "context",
+                                "elements": [
+                                    {
+                                        "type": "mrkdwn",
+                                        "text": "*Environment: *\n ${{ matrix.environment }}  \n"
+                                    },
+                                    {
+                                        "type": "mrkdwn",
+                                        "text": " "
+                                    },
+                                    {
+                                        "type": "mrkdwn",
+                                        "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+                                },
+                                "accessory": {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "View on Github",
+                                        "emoji": true
+                                    },
+                                    "value": "click_me_123",
+                                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                                    "action_id": "button-action",
+                                    "style": "primary"
+                                }
                             }
                         ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "primary"
-                        }
                     }
                 ]
             }

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -21,15 +21,21 @@ on:
           - staging
           - production
           - india
+  schedule:
+    - cron: '30 6 * * *'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job_id }}
+          name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -83,6 +83,15 @@ jobs:
           echo ${{env.NOW}}
           pytest -v --rootdir= HQSmokeTests/testCases -n 4 --dist=loadfile --reruns 1 --html=report_${{ matrix.environment }}.html
 
+      - name: Parse test counts
+        id: parse_counts
+        if: always()
+        run: |
+          # Extract variables from the hqsmoke_test_counts.txt file
+          while IFS= read -r line; do
+            echo "::set-output name=${line%=*}::${line#*=}"
+          done < hqsmoke_test_counts_${{ matrix.environment }}.txt
+
       - name: Set email vars
         if: ${{ failure() }}
         id: configure_email
@@ -215,17 +224,24 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
+                            "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
                             "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
                         },
                         "accessory": {
                             "type": "button",
                             "text": {
                                 "type": "plain_text",
-                                "text": "View on Github",
+                                "text": "View Report",
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html",
                             "action_id": "button-action",
                             "style": "danger"
                         }
@@ -278,11 +294,11 @@ jobs:
                             "type": "button",
                             "text": {
                                 "type": "plain_text",
-                                "text": "View on Github",
+                                "text": "View Report",
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html"
                             "action_id": "button-action",
                             "style": "primary"
                         }

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -98,6 +98,19 @@ jobs:
             echo "::set-output name=${line%=*}::${line#*=}"
           done < hqsmoke_test_counts_${{ matrix.environment }}.txt
 
+      - name: Archive test results
+        id: artifact-upload-step
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-reports-${{ github.job }}
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          retention-days: 2
+
+      - name: Fetch artifact ID
+        run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+
+
       - name: Set email vars
         if: ${{ failure() }}
         id: configure_email
@@ -250,7 +263,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-                                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "danger"
             					}
@@ -319,7 +332,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}
@@ -332,11 +345,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: Archive test results
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-result-reports-${{ matrix.environment }}
-          path: ${{ github.workspace }}/report_${{ matrix.environment }}.html
-          retention-days: 2

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
-          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html
           retention-days: 2
 
       - name: Fetch artifact ID
@@ -322,17 +322,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View Test Summary",
+            							"text": "Click to Download",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -241,7 +241,7 @@ jobs:
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "${{ github.workspace }}/report_${{ matrix.environment }}.html",
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                             "action_id": "button-action",
                             "style": "danger"
                         }
@@ -298,7 +298,7 @@ jobs:
                                 "emoji": true
                             },
                             "value": "click_me_123",
-                            "url": "${{ github.workspace }}/report_${{ matrix.environment }}.html",
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                             "action_id": "button-action",
                             "style": "primary"
                         }

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -22,7 +22,7 @@ on:
           - production
           - india
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '30 6 * * 1-5'
 
 jobs:
   set_matrix:
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -206,7 +206,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -230,20 +230,13 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
                             "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
                         },
                         "accessory": {
                             "type": "button",
                             "text": {
                                 "type": "plain_text",
-                                "text": "View Report",
+                                "text": "View on Github",
                                 "emoji": true
                             },
                             "value": "click_me_123",
@@ -270,7 +263,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n\n*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -300,7 +293,7 @@ jobs:
                             "type": "button",
                             "text": {
                                 "type": "plain_text",
-                                "text": "View Report",
+                                "text": "View on Github",
                                 "emoji": true
                             },
                             "value": "click_me_123",

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -269,70 +269,69 @@ jobs:
         if: ${{ steps.configure_slack.outputs.result != ' ' && success() }}
         with:
           payload: |
-             {
-                "attachments": [
-                    {
-                        "color": "#36a64f",
-                        "blocks": [
-                            {
-                                "type": "section",
-                                "text": {
-                                    "type": "mrkdwn",
-                                    "text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n"
-                                }
-                            },
-                            {
-                                 "type": "section",
-                                 "text": {
-                                     "type": "mrkdwn",
-                                     "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                                }
-                            },
-                            {
-                                "type": "context",
-                                "elements": [
-                                    {
-                                        "type": "mrkdwn",
-                                        "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                                    },
-                                    {
-                                        "type": "mrkdwn",
-                                        "text": " "
-                                    },
-                                    {
-                                        "type": "mrkdwn",
-                                        "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "section",
-                                "text": {
-                                    "type": "mrkdwn",
-                                    "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                                },
-                                "accessory": {
-                                    "type": "button",
-                                    "text": {
-                                        "type": "plain_text",
-                                        "text": "View on Github",
-                                        "emoji": true
-                                    },
-                                    "value": "click_me_123",
-                                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                                    "action_id": "button-action",
-                                    "style": "primary"
-                                }
-                            }
-                        ]
-                    }
-                ]
+            {
+            	"attachments": [
+            		{
+            			"color": "#36a64f",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Bonjour :alphabet-yellow-q::alphabet-yellow-a: 👋 \n*${{ github.workflow }}* were just triggered!\n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "primary"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
+
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
 
       - name: Archive test results
         if: ${{ success() || failure() }}

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -322,17 +322,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "Click to Downlaod",
+            							"text": "View Test Summary",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/hq-smoke-tests.yml
+++ b/.github/workflows/hq-smoke-tests.yml
@@ -253,13 +253,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
@@ -322,13 +322,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -83,6 +83,18 @@ jobs:
             echo "::set-output name=${line%=*}::${line#*=}"
           done < ms_test_counts_${{ matrix.environment }}.txt
 
+      - name: Archive test results
+        id: artifact-upload-step
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result-reports-${{ github.job }}
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          retention-days: 2
+
+      - name: Fetch artifact ID
+        run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+
       - name: Set email vars
         if: ${{ success() || failure() }}
         id: configure_email
@@ -230,7 +242,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "danger"
             					}
@@ -299,7 +311,7 @@ jobs:
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}
@@ -311,11 +323,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
-      - name: Archive test results
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-result-reports-${{ matrix.environment }}
-          path: ${{ github.workspace }}/report_${{ matrix.environment }}.html

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -232,13 +232,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",
@@ -301,13 +301,13 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View on Github",
+            							"text": "Click to Downlaod",
             							"emoji": true
             						},
             						"value": "click_me_123",

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -16,7 +16,7 @@ on:
         options:
           - staging
           - production
-schedule:
+  schedule:
     - cron: '30 7 * * 1-5'
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job }}
+          name: test-result-reports-${{ github.job_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -181,51 +181,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :x:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "danger"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#ff0000",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :x:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "danger"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
@@ -238,51 +250,63 @@ jobs:
         with:
           payload: |
             {
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                        }
-                    },
-                    {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                            },
-                          {
-                                "type": "mrkdwn",
-                                "text": " "
-                            },
-                            {
-                                "type": "mrkdwn",
-                                "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View on Github",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                            "action_id": "button-action",
-                            "style": "primary"
-                        }
-                    }
-                ]
+            	"attachments": [
+            		{
+            			"color": "#36a64f",
+            			"blocks": [
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n"
+            					}
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+            					}
+            				},
+            				{
+            					"type": "context",
+            					"elements": [
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": " "
+            						},
+            						{
+            							"type": "mrkdwn",
+            							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+            						}
+            					]
+            				},
+            				{
+            					"type": "section",
+            					"text": {
+            						"type": "mrkdwn",
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            					},
+            					"accessory": {
+            						"type": "button",
+            						"text": {
+            							"type": "plain_text",
+            							"text": "View on Github",
+            							"emoji": true
+            						},
+            						"value": "click_me_123",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"action_id": "button-action",
+            						"style": "primary"
+            					}
+            				}
+            			]
+            		}
+            	]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-reports-${{ github.job_id }}
+          name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
           path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
           retention-days: 2
 

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -301,17 +301,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "Click to Downlaod",
+            							"text": "View Test Summary",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -16,15 +16,21 @@ on:
         options:
           - staging
           - production
+schedule:
+    - cron: '30 7 * * 1-5'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -67,6 +73,15 @@ jobs:
           echo "NOW=$(date +'%m-%d %H:%M')" >> $GITHUB_ENV
           echo ${{env.NOW}}
           pytest -v "./Features/MultiSelect/test_cases" --dist=loadfile --reruns 1 --html=report_${{ matrix.environment }}.html
+
+      - name: Parse test counts
+        id: parse_counts
+        if: always()
+        run: |
+          # Extract variables from the hqsmoke_test_counts.txt file
+          while IFS= read -r line; do
+            echo "::set-output name=${line%=*}::${line#*=}"
+          done < ms_test_counts_${{ matrix.environment }}.txt
 
       - name: Set email vars
         if: ${{ success() || failure() }}
@@ -171,7 +186,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -228,7 +243,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!"
+                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-result-reports--${{ matrix.environment }}-${{ github.run_id }}
-          path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+          path: /home/runner/work/dimagi-qa/dimagi-qa/report_${{ matrix.environment }}.html
           retention-days: 2
 
       - name: Fetch artifact ID
@@ -301,17 +301,17 @@ jobs:
             					"type": "section",
             					"text": {
             						"type": "mrkdwn",
-            						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+            						"text": "Here's the corresponding report :arrow_right::arrow_right:"
             					},
             					"accessory": {
             						"type": "button",
             						"text": {
             							"type": "plain_text",
-            							"text": "View Test Summary",
+            							"text": "Click to Download",
             							"emoji": true
             						},
             						"value": "click_me_123",
-            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
             						"action_id": "button-action",
             						"style": "primary"
             					}

--- a/.github/workflows/multi-select-tests.yml
+++ b/.github/workflows/multi-select-tests.yml
@@ -186,7 +186,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {
@@ -243,7 +243,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                            "text": " Ciao :woman-raising-hand::skin-tone-3::man-raising-hand::skin-tone-3: \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                         }
                     },
                     {

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -82,6 +82,7 @@ jobs:
 
     - name: Parse test counts
       id: parse_counts
+      if: always()
       run: |
         # Extract variables from the test_counts.txt file
         while IFS= read -r line; do
@@ -172,7 +173,7 @@ jobs:
                               "type": "mrkdwn",
                               "text": "*Environment: *\n ${{ matrix.environment }}  \n"
                           },
-                        {
+                          {
                               "type": "mrkdwn",
                               "text": " "
                           },
@@ -217,10 +218,10 @@ jobs:
                               "type": "mrkdwn",
                               "text": " "
                           },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*XFail: *\n ${{ steps.parse_counts.outputs.XFAIL }} \n"
-                        },
+                          {
+                              "type": "mrkdwn",
+                              "text": "*XFail: *\n ${{ steps.parse_counts.outputs.XFAIL }} \n"
+                          }
                       ]
                   },
                   {

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -100,11 +100,11 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-result-reports
+        name: test-result-reports-${{ github.job }}
         path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
         retention-days: 2
 
-    - name: Fetch artifact URL
+    - name: Fetch artifact ID
       run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
 
     - name: Send Failure Email

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -195,7 +195,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "${{ github.workspace }}/report_api_${{ matrix.environment }}.html",
+                          "url": "file%3A%2F%2F%2Fhome%2Frunner%2Fwork%2Fdimagi-qa%2Fdimagi-qa%2Freport_api_staging.html",
                           "action_id": "button-action",
                           "style": "danger"
                       }
@@ -260,7 +260,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "${{ github.workspace }}/report_api_${{ matrix.environment }}.html",
+                          "url": "file%3A%2F%2F%2Fhome%2Frunner%2Fwork%2Fdimagi-qa%2Fdimagi-qa%2Freport_api_staging.html",
                           "action_id": "button-action",
                           "style": "primary"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -100,7 +100,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-result-reports-${{ github.job }}
+        name: test-result-reports-${{ github.job_id }}
         path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
         retention-days: 2
 

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -21,7 +21,7 @@ on:
           - staging
           - production
           - india
-schedule:
+  schedule:
     - cron: '30 6 * * 1-5'
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -195,7 +195,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
+                          "url": "${{ github.workspace }}/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "danger"
                       }
@@ -260,7 +260,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
+                          "url": "${{ github.workspace }}/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "primary"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -155,51 +155,63 @@ jobs:
       with:
         payload: |
           {
-              "blocks": [
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                      }
-                  },
-                  {
-                      "type": "context",
-                      "elements": [
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Status: *\n ${{ job.status }}  :x:"
-                          }
-                      ]
-                  },
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": "Here's the corresponding report :arrow_right::arrow_right:"
-                      },
-                      "accessory": {
-                          "type": "button",
-                          "text": {
-                              "type": "plain_text",
-                              "text": "View on Github",
-                              "emoji": true
-                          },
-                          "value": "click_me_123",
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                          "action_id": "button-action",
-                          "style": "danger"
-                      }
-                  }
-              ]
+          	"attachments": [
+          		{
+          			"color": "#ff0000",
+          			"blocks": [
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n"
+          					}
+          				},
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+          					}
+          				},
+          				{
+          					"type": "context",
+          					"elements": [
+          						{
+          							"type": "mrkdwn",
+          							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+          						},
+          						{
+          							"type": "mrkdwn",
+          							"text": " "
+          						},
+          						{
+          							"type": "mrkdwn",
+          							"text": "*Status: *\n ${{ job.status }}  :x:"
+          						}
+          					]
+          				},
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+          					},
+          					"accessory": {
+          						"type": "button",
+          						"text": {
+          							"type": "plain_text",
+          							"text": "View on Github",
+          							"emoji": true
+          						},
+          						"value": "click_me_123",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          						"action_id": "button-action",
+          						"style": "danger"
+          					}
+          				}
+          			]
+          		}
+          	]
           }
         parse-json-secrets: true
       env:
@@ -213,51 +225,63 @@ jobs:
       with:
         payload: |
           {
-              "blocks": [
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                      }
-                  },
-                  {
-                      "type": "context",
-                      "elements": [
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Environment: *\n ${{ matrix.environment }}  \n"
-                          },
-                        {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
-                          }
-                      ]
-                  },
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
-                      },
-                      "accessory": {
-                          "type": "button",
-                          "text": {
-                              "type": "plain_text",
-                              "text": "View on Github",
-                              "emoji": true
-                          },
-                          "value": "click_me_123",
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                          "action_id": "button-action",
-                          "style": "primary"
-                      }
-                  }
-              ]
+          	"attachments": [
+          		{
+          			"color": "#36a64f",
+          			"blocks": [
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n"
+          					}
+          				},
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }} *Failed:* ${{ steps.parse_counts.outputs.FAILED }} *Error:* ${{ steps.parse_counts.outputs.ERROR }} *Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }} *XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+          					}
+          				},
+          				{
+          					"type": "context",
+          					"elements": [
+          						{
+          							"type": "mrkdwn",
+          							"text": "*Environment: *\n ${{ matrix.environment }}  \n"
+          						},
+          						{
+          							"type": "mrkdwn",
+          							"text": " "
+          						},
+          						{
+          							"type": "mrkdwn",
+          							"text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
+          						}
+          					]
+          				},
+          				{
+          					"type": "section",
+          					"text": {
+          						"type": "mrkdwn",
+          						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+          					},
+          					"accessory": {
+          						"type": "button",
+          						"text": {
+          							"type": "plain_text",
+          							"text": "View on Github",
+          							"emoji": true
+          						},
+          						"value": "click_me_123",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          						"action_id": "button-action",
+          						"style": "primary"
+          					}
+          				}
+          			]
+          		}
+          	]
           }
         parse-json-secrets: true
       env:

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -100,7 +100,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-result-reports-${{ github.job_id }}
+        name: test-result-reports-${{ matrix.environment }}-${{ github.run_id }}
         path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
         retention-days: 2
 

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -154,7 +154,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n Here is the link to report: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html"
                       }
                   },
                   {
@@ -178,14 +178,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                      }
-                  },
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": "Here's the corresponding report :arrow_right::arrow_right:"
+                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\nHere's the corresponding report :arrow_right::arrow_right:"
                       },
                       "accessory": {
                           "type": "button",
@@ -219,7 +212,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n Here is the link to report: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html"
                       }
                   },
                   {
@@ -243,14 +236,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
-                      }
-                  },
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\nHere's the corresponding workflow execution :arrow_right::arrow_right:"
                       },
                       "accessory": {
                           "type": "button",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -186,13 +186,12 @@ jobs:
                   {
                       "type": "section",
                       "text": {
-
-                              "type": "mrkdwn",
-                              "text": "*Passed: * ${{ steps.parse_counts.outputs.PASSED }} \n
-                                       *Failed: * ${{ steps.parse_counts.outputs.FAILED }} \n
-                                       *Error: * ${{ steps.parse_counts.outputs.ERROR }} \n
-                                       *Skipped: * ${{ steps.parse_counts.outputs.SKIPPED }} \n
-                                       *XFail: * ${{ steps.parse_counts.outputs.XFAIL }} \n"
+                          "type": "mrkdwn",
+                          "text": "*Passed: * ${{ steps.parse_counts.outputs.PASSED }} \n
+                                  *Failed: * ${{ steps.parse_counts.outputs.FAILED }} \n
+                                  *Error: * ${{ steps.parse_counts.outputs.ERROR }} \n
+                                  *Skipped: * ${{ steps.parse_counts.outputs.SKIPPED }} \n
+                                  *XFail: * ${{ steps.parse_counts.outputs.XFAIL }} \n"
                       }
                   },
                   {

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -212,7 +212,7 @@ jobs:
           						"type": "button",
           						"text": {
           							"type": "plain_text",
-          							"text": "View on Github",
+          							"text": "Click to Downlaod",
           							"emoji": true
           						},
           						"value": "click_me_123",
@@ -276,13 +276,13 @@ jobs:
           					"type": "section",
           					"text": {
           						"type": "mrkdwn",
-          						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+          						"text": "Here's the corresponding report :arrow_right::arrow_right:"
           					},
           					"accessory": {
           						"type": "button",
           						"text": {
           							"type": "plain_text",
-          							"text": "View on Github",
+          							"text": "Click to Downlaod",
           							"emoji": true
           						},
           						"value": "click_me_123",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -80,6 +80,25 @@ jobs:
         echo ${{env.NOW}}
         pytest -v --tb=short -n auto --dist=loadfile --reruns 1 --html=report_api_${{ matrix.environment }}.html --self-contained-html --rootdir= RequestAPI/testCases
 
+  pytest
+
+  - name: Parse test counts
+    id: parse_counts
+    run: |
+      # Extract variables from the test_counts.txt file
+      while IFS= read -r line; do
+        echo "::set-output name=${line%=*}::${line#*=}"
+      done < api_test_counts.txt
+
+  - name: Display test counts
+    run: |
+      echo "Passed tests: ${{ steps.parse_counts.outputs.PASSED }}"
+      echo "Failed tests: ${{ steps.parse_counts.outputs.FAILED }}"
+      echo "Error tests: ${{ steps.parse_counts.outputs.ERROR }}"
+      echo "Skipped tests: ${{ steps.parse_counts.outputs.SKIPPED }}"
+      echo "Xfail tests: ${{ steps.parse_counts.outputs.XFAIL }}"
+
+
     - name: Send Failure Email
       uses: dawidd6/action-send-mail@v3
       if: failure()
@@ -131,6 +150,8 @@ jobs:
 
           return SLACK_WEBHOOK_URL
 
+
+
     - name: Post to Slack channel on Failure
       id: slack-api-staging-fail
       uses: slackapi/slack-github-action@v1.23.0
@@ -164,10 +185,51 @@ jobs:
                       ]
                   },
                   {
+                      "type": "context",
+                      "elements": [
+                          {
+                              "type": "mrkdwn",
+                              "text": "*Passed: *\n ${{ steps.parse_counts.outputs.PASSED }}  \n"
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": " "
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": "*Failed: *\n ${{ steps.parse_counts.outputs.FAILED }} \n"
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": " "
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": "*Error: *\n ${{ steps.parse_counts.outputs.ERROR }} \n"
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": " "
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": "*Skipped: *\n ${{ steps.parse_counts.outputs.SKIPPED }} \n"
+                          },
+                          {
+                              "type": "mrkdwn",
+                              "text": " "
+                          },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*XFail: *\n ${{ steps.parse_counts.outputs.XFAIL }} \n"
+                        },
+                      ]
+                  },
+                  {
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+                          "text": "Here's the corresponding report :arrow_right::arrow_right:"
                       },
                       "accessory": {
                           "type": "button",
@@ -177,7 +239,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                          "url": "/home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "danger"
                       }
@@ -235,7 +297,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                          "url": "/home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "primary"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -276,17 +276,17 @@ jobs:
           					"type": "section",
           					"text": {
           						"type": "mrkdwn",
-          						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
+          						"text": "Here's the corresponding report :arrow_right::arrow_right:"
           					},
           					"accessory": {
           						"type": "button",
           						"text": {
           							"type": "plain_text",
-          							"text": "View Test Summary",
+          							"text": "Click to Downlaod",
           							"emoji": true
           						},
           						"value": "click_me_123",
-          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
           						"action_id": "button-action",
           						"style": "primary"
           					}

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -160,7 +160,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {
@@ -218,7 +218,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n\n *Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -187,11 +187,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Passed: * ${{ steps.parse_counts.outputs.PASSED }} \n
-                                  *Failed: * ${{ steps.parse_counts.outputs.FAILED }} \n
-                                  *Error: * ${{ steps.parse_counts.outputs.ERROR }} \n
-                                  *Skipped: * ${{ steps.parse_counts.outputs.SKIPPED }} \n
-                                  *XFail: * ${{ steps.parse_counts.outputs.XFAIL }} \n"
+                          "text": "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {
@@ -208,7 +204,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "/home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
+                          "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "danger"
                       }
@@ -266,7 +262,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "/home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
+                          "url": "file:///home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html",
                           "action_id": "button-action",
                           "style": "primary"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -260,7 +260,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "file%3A%2F%2F%2Fhome%2Frunner%2Fwork%2Fdimagi-qa%2Fdimagi-qa%2Freport_api_staging.html",
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "action_id": "button-action",
                           "style": "primary"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -187,7 +187,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {
@@ -247,6 +247,13 @@ jobs:
                               "text": "*Status: *\n ${{ job.status }}  :white_check_mark:"
                           }
                       ]
+                  },
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
+                      }
                   },
                   {
                       "type": "section",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -21,15 +21,21 @@ on:
           - staging
           - production
           - india
+schedule:
+    - cron: '30 6 * * 1-5'
 
 jobs:
   set_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
+      matrix: ${{ steps.set-matrix-schedule.outputs.matrix || steps.set-matrix-deploy.outputs.matrix || steps.set-matrix-manual.outputs.matrix || steps.set-matrix-default.outputs.matrix }}
     steps:
+      - id: set-matrix-schedule
+        if: ${{ github.event_name  == 'schedule' }}
+        run: |
+          echo "::set-output name=matrix::{\"environment\": [\"staging\"]}"
       - id: set-matrix-deploy
-        if: ${{ github.event_name == 'repository_dispatch' }}
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment !== 'staging' }}
         run: |
           echo "::set-output name=matrix::{\"environment\": [\"${{ github.event.client_payload.environment }}\"]}"
       - id: set-matrix-manual
@@ -154,7 +160,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n Here is the link to report: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered!\n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {
@@ -178,13 +184,13 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\nHere's the corresponding report :arrow_right::arrow_right:"
+                          "text": "Here's the corresponding report :arrow_right::arrow_right:"
                       },
                       "accessory": {
                           "type": "button",
                           "text": {
                               "type": "plain_text",
-                              "text": "View Report",
+                              "text": "View on Github",
                               "emoji": true
                           },
                           "value": "click_me_123",
@@ -212,7 +218,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n Here is the link to report: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html"
+                          "text": " Hola  👋 \n*${{ github.workflow }}* were just triggered! \n\n "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\n"
                       }
                   },
                   {
@@ -236,13 +242,13 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Passed:* ${{ steps.parse_counts.outputs.PASSED }}\n*Failed:* ${{ steps.parse_counts.outputs.FAILED }}\n*Error:* ${{ steps.parse_counts.outputs.ERROR }}\n*Skipped:* ${{ steps.parse_counts.outputs.SKIPPED }}\n*XFail:* ${{ steps.parse_counts.outputs.XFAIL }}\nHere's the corresponding workflow execution :arrow_right::arrow_right:"
+                          "text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
                       },
                       "accessory": {
                           "type": "button",
                           "text": {
                               "type": "plain_text",
-                              "text": "View Report",
+                              "text": "View on Github",
                               "emoji": true
                           },
                           "value": "click_me_123",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -95,6 +95,14 @@ jobs:
           echo "::set-output name=${line%=*}::${line#*=}"
         done < test_counts_${{ matrix.environment }}.txt
 
+    - name: Archive test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-result-reports
+        path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
+        retention-days: 2
+
     - name: Send Failure Email
       uses: dawidd6/action-send-mail@v3
       if: failure()
@@ -287,12 +295,3 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.configure_slack.outputs.result }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
-    - name: Archive test results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-result-reports
-        path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
-        retention-days: 2

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -96,12 +96,16 @@ jobs:
         done < test_counts_${{ matrix.environment }}.txt
 
     - name: Archive test results
+      id: artifact-upload-step
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-result-reports
         path: /home/runner/work/dimagi-qa/dimagi-qa/report_api_${{ matrix.environment }}.html
         retention-days: 2
+
+    - name: Fetch artifact URL
+      run: echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
 
     - name: Send Failure Email
       uses: dawidd6/action-send-mail@v3
@@ -212,7 +216,7 @@ jobs:
           							"emoji": true
           						},
           						"value": "click_me_123",
-          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
           						"action_id": "button-action",
           						"style": "danger"
           					}
@@ -282,7 +286,7 @@ jobs:
           							"emoji": true
           						},
           						"value": "click_me_123",
-          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
           						"action_id": "button-action",
           						"style": "primary"
           					}

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -89,15 +89,6 @@ jobs:
           echo "::set-output name=${line%=*}::${line#*=}"
         done < test_counts_${{ matrix.environment }}.txt
 
-    - name: Display test counts
-      run: |
-        echo "Passed tests: ${{ steps.parse_counts.outputs.PASSED }}"
-        echo "Failed tests: ${{ steps.parse_counts.outputs.FAILED }}"
-        echo "Error tests: ${{ steps.parse_counts.outputs.ERROR }}"
-        echo "Skipped tests: ${{ steps.parse_counts.outputs.SKIPPED }}"
-        echo "Xfail tests: ${{ steps.parse_counts.outputs.XFAIL }}"
-
-
     - name: Send Failure Email
       uses: dawidd6/action-send-mail@v3
       if: failure()
@@ -200,7 +191,7 @@ jobs:
                           "type": "button",
                           "text": {
                               "type": "plain_text",
-                              "text": "View on Github",
+                              "text": "View Report",
                               "emoji": true
                           },
                           "value": "click_me_123",
@@ -265,7 +256,7 @@ jobs:
                           "type": "button",
                           "text": {
                               "type": "plain_text",
-                              "text": "View on Github",
+                              "text": "View Report",
                               "emoji": true
                           },
                           "value": "click_me_123",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -84,10 +84,10 @@ jobs:
       id: parse_counts
       if: always()
       run: |
-        # Extract variables from the test_counts.txt file
+        # Extract variables from the api_test_counts.txt file
         while IFS= read -r line; do
           echo "::set-output name=${line%=*}::${line#*=}"
-        done < api_test_counts.txt
+        done < test_counts_${{ matrix.environment }}.txt
 
     - name: Display test counts
       run: |
@@ -184,45 +184,16 @@ jobs:
                       ]
                   },
                   {
-                      "type": "context",
-                      "elements": [
-                          {
+                      "type": "section",
+                      "text": {
+
                               "type": "mrkdwn",
-                              "text": "*Passed: *\n ${{ steps.parse_counts.outputs.PASSED }}  \n"
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Failed: *\n ${{ steps.parse_counts.outputs.FAILED }} \n"
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Error: *\n ${{ steps.parse_counts.outputs.ERROR }} \n"
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*Skipped: *\n ${{ steps.parse_counts.outputs.SKIPPED }} \n"
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": " "
-                          },
-                          {
-                              "type": "mrkdwn",
-                              "text": "*XFail: *\n ${{ steps.parse_counts.outputs.XFAIL }} \n"
-                          }
-                      ]
+                              "text": "*Passed: * ${{ steps.parse_counts.outputs.PASSED }} \n
+                                       *Failed: * ${{ steps.parse_counts.outputs.FAILED }} \n
+                                       *Error: * ${{ steps.parse_counts.outputs.ERROR }} \n
+                                       *Skipped: * ${{ steps.parse_counts.outputs.SKIPPED }} \n
+                                       *XFail: * ${{ steps.parse_counts.outputs.XFAIL }} \n"
+                      }
                   },
                   {
                       "type": "section",

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -276,17 +276,17 @@ jobs:
           					"type": "section",
           					"text": {
           						"type": "mrkdwn",
-          						"text": "Here's the corresponding report :arrow_right::arrow_right:"
+          						"text": "Here's the corresponding workflow execution :arrow_right::arrow_right:"
           					},
           					"accessory": {
           						"type": "button",
           						"text": {
           							"type": "plain_text",
-          							"text": "Click to Downlaod",
+          							"text": "View Test Summary",
           							"emoji": true
           						},
           						"value": "click_me_123",
-          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}",
+          						"url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
           						"action_id": "button-action",
           						"style": "primary"
           					}

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -188,7 +188,7 @@ jobs:
                               "emoji": true
                           },
                           "value": "click_me_123",
-                          "url": "file%3A%2F%2F%2Fhome%2Frunner%2Fwork%2Fdimagi-qa%2Fdimagi-qa%2Freport_api_staging.html",
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                           "action_id": "button-action",
                           "style": "danger"
                       }

--- a/.github/workflows/request_api.yml
+++ b/.github/workflows/request_api.yml
@@ -80,23 +80,21 @@ jobs:
         echo ${{env.NOW}}
         pytest -v --tb=short -n auto --dist=loadfile --reruns 1 --html=report_api_${{ matrix.environment }}.html --self-contained-html --rootdir= RequestAPI/testCases
 
-  pytest
+    - name: Parse test counts
+      id: parse_counts
+      run: |
+        # Extract variables from the test_counts.txt file
+        while IFS= read -r line; do
+          echo "::set-output name=${line%=*}::${line#*=}"
+        done < api_test_counts.txt
 
-  - name: Parse test counts
-    id: parse_counts
-    run: |
-      # Extract variables from the test_counts.txt file
-      while IFS= read -r line; do
-        echo "::set-output name=${line%=*}::${line#*=}"
-      done < api_test_counts.txt
-
-  - name: Display test counts
-    run: |
-      echo "Passed tests: ${{ steps.parse_counts.outputs.PASSED }}"
-      echo "Failed tests: ${{ steps.parse_counts.outputs.FAILED }}"
-      echo "Error tests: ${{ steps.parse_counts.outputs.ERROR }}"
-      echo "Skipped tests: ${{ steps.parse_counts.outputs.SKIPPED }}"
-      echo "Xfail tests: ${{ steps.parse_counts.outputs.XFAIL }}"
+    - name: Display test counts
+      run: |
+        echo "Passed tests: ${{ steps.parse_counts.outputs.PASSED }}"
+        echo "Failed tests: ${{ steps.parse_counts.outputs.FAILED }}"
+        echo "Error tests: ${{ steps.parse_counts.outputs.ERROR }}"
+        echo "Skipped tests: ${{ steps.parse_counts.outputs.SKIPPED }}"
+        echo "Xfail tests: ${{ steps.parse_counts.outputs.XFAIL }}"
 
 
     - name: Send Failure Email

--- a/Features/CaseSearch/test_cases/conftest.py
+++ b/Features/CaseSearch/test_cases/conftest.py
@@ -59,3 +59,23 @@ def settings(environment_settings_casesearch):
     settings = ConfigParser()
     settings.read(path)
     return settings["default"]
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
+    # Write the counts to a file
+    # Determine the environment
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'cs_test_counts_{env}.txt'
+    with open(filename, 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/Features/MultiSelect/test_cases/conftest.py
+++ b/Features/MultiSelect/test_cases/conftest.py
@@ -59,3 +59,23 @@ def settings(environment_settings_multiselect):
     settings = ConfigParser()
     settings.read(path)
     return settings["default"]
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
+    # Write the counts to a file
+    # Determine the environment
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'ms_test_counts_{env}.txt'
+    with open(filename, 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/Features/SplitScreenCaseSearch/test_cases/conftest.py
+++ b/Features/SplitScreenCaseSearch/test_cases/conftest.py
@@ -108,3 +108,23 @@ def settings(environment_settings_sscs):
     settings = ConfigParser()
     settings.read(path)
     return settings["default"]
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
+    # Write the counts to a file
+    # Determine the environment
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'sscs_test_counts_{env}.txt'
+    with open(filename, 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/HQSmokeTests/testCases/conftest.py
+++ b/HQSmokeTests/testCases/conftest.py
@@ -70,3 +70,24 @@ def settings(environment_settings_hq):
     else:
         settings["default"]["url"] = f"{settings['default']['url']}a/qa-automation"
     return settings["default"]
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
+
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'hqsmoke_test_counts_{env}.txt'
+
+    # Write the counts to a file
+    with open(filename, 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/RequestAPI/testCases/conftest.py
+++ b/RequestAPI/testCases/conftest.py
@@ -73,9 +73,17 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     error = terminalreporter.stats.get('error', [])
     skipped = terminalreporter.stats.get('skipped', [])
     xfail = terminalreporter.stats.get('xfail', [])
-
+    env = config.getoptions("--settings")
     # Write the counts to a file
-    with open('api_test_counts.txt', 'w') as f:
+    settings = config._get_config_var('settings')
+    env_settings = "\n".join(f"{key}={value}" for key, value in settings.items())
+
+    # Determine the environment
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'test_counts_{env}.txt'
+    with open(filename, 'w') as f:
         f.write(f'PASSED={len(passed)}\n')
         f.write(f'FAILED={len(failed)}\n')
         f.write(f'ERROR={len(error)}\n')

--- a/RequestAPI/testCases/conftest.py
+++ b/RequestAPI/testCases/conftest.py
@@ -66,4 +66,18 @@ def pytest_runtest_makereport(item):
             print("reports skipped or failed")
         report.extra = extra
 
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
 
+    # Write the counts to a file
+    with open('api_test_counts.txt', 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/RequestAPI/testCases/conftest.py
+++ b/RequestAPI/testCases/conftest.py
@@ -75,9 +75,6 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     xfail = terminalreporter.stats.get('xfail', [])
     env = config.getoptions("--settings")
     # Write the counts to a file
-    settings = config._get_config_var('settings')
-    env_settings = "\n".join(f"{key}={value}" for key, value in settings.items())
-
     # Determine the environment
     env = os.environ.get("DIMAGIQA_ENV", "default_env")
 

--- a/RequestAPI/testCases/conftest.py
+++ b/RequestAPI/testCases/conftest.py
@@ -73,7 +73,6 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     error = terminalreporter.stats.get('error', [])
     skipped = terminalreporter.stats.get('skipped', [])
     xfail = terminalreporter.stats.get('xfail', [])
-    env = config.getoptions("--settings")
     # Write the counts to a file
     # Determine the environment
     env = os.environ.get("DIMAGIQA_ENV", "default_env")

--- a/USH_Apps/CO_BHA/test_cases/conftest.py
+++ b/USH_Apps/CO_BHA/test_cases/conftest.py
@@ -118,3 +118,23 @@ def settings(environment_settings_bha):
     settings = ConfigParser()
     settings.read(path)
     return settings["default"]
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # Collect test counts
+    passed = terminalreporter.stats.get('passed', [])
+    failed = terminalreporter.stats.get('failed', [])
+    error = terminalreporter.stats.get('error', [])
+    skipped = terminalreporter.stats.get('skipped', [])
+    xfail = terminalreporter.stats.get('xfail', [])
+    # Write the counts to a file
+    # Determine the environment
+    env = os.environ.get("DIMAGIQA_ENV", "default_env")
+
+    # Define the filename based on the environment
+    filename = f'bha_test_counts_{env}.txt'
+    with open(filename, 'w') as f:
+        f.write(f'PASSED={len(passed)}\n')
+        f.write(f'FAILED={len(failed)}\n')
+        f.write(f'ERROR={len(error)}\n')
+        f.write(f'SKIPPED={len(skipped)}\n')
+        f.write(f'XFAIL={len(xfail)}\n')

--- a/common_utilities/fixtures.py
+++ b/common_utilities/fixtures.py
@@ -111,7 +111,5 @@ def pytest_runtest_makereport(item):
                 extra.append(pytest_html.extras.html(html))
         report.extra = extra
         report.tags = tags
-
-
 def _capture_screenshot(web_driver):
     return web_driver.get_screenshot_as_base64()

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ addopts =
     --html=report.html
     --self-contained-html
     --tb=short
+


### PR DESCRIPTION
## Summary
Made changes to all the active testsuite workflows for a better slack notification.

## Description
Made changes to all the active testsuite workflows for a better slack notification.
- The notifications will have the test pass, fail, skip, xfail, error counts
- There will be a red bar for failed executions and green for a success one
- A click button will directly download the report zip file.
<img width="419" alt="image" src="https://github.com/user-attachments/assets/9c4fec34-1135-490c-83b9-744804998fff">


### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-5310)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated