### PR TITLE
QA-7428 added the scripts for Oncho load tests

### DIFF
--- a/LocustScripts/update-scripts/commcarehq-v2-it.py
+++ b/LocustScripts/update-scripts/commcarehq-v2-it.py
@@ -1,0 +1,167 @@
+import logging
+import random
+import string
+
+import time
+from datetime import datetime
+
+from locust import SequentialTaskSet, between, task, tag, events
+from locust.exception import InterruptTaskSet
+
+from user.models import UserDetails, BaseLoginCommCareUser
+from common.args import file_path
+from common.utils import RandomItems, load_json_data
+import coloredlogs
+
+logger = logging.getLogger(__name__)
+level_styles = {
+    'critical': {'color': 'red', 'bold': True},
+    'error': {'color': 'red'},
+    'warning': {'color': 'yellow'},
+    'debug': {'color': 'green', 'bold': True},
+    'notset': {'color': 'cyan'},
+    'info': {'color': 'white'}
+    }
+coloredlogs.install(logger=logger, level='DEBUG', level_styles=level_styles
+                    )  # install a handler on the root logger with level debug
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    # Use below command to execute these tests:
+    # locust -f .\LocustScripts\update-scripts\commcarehq-v2-it.py --domain alafiacomm --build-id e010117e07ab3f47a1fdad6da7f0bfb9 --app-id 791fcbb98a0c4ffeb4aa38f20fd3544b --app-config .\LocustScripts\update-scripts\project-config\co-carecoordination-perf\app_config_v2_it_test.json --user-details .\LocustScripts\update-scripts\project-config\co-carecoordination-perf\mobile_worker_it_credentials.json
+
+    parser.add_argument("--domain", help="CommCare domain", required=True, env_var="COMMCARE_DOMAIN")
+    parser.add_argument("--build-id", help="CommCare build id", required=True, env_var="COMMCARE_APP_ID")
+    parser.add_argument("--app-id", help="CommCare app id", required=True, env_var="COMMCARE_APP_ID")
+    parser.add_argument("--app-config", help="Configuration of CommCare app", required=True)
+    parser.add_argument("--user-details", help="Path to user details file", required=True)
+
+
+APP_CONFIG = {}
+USERS_DETAILS = RandomItems()
+
+
+@events.init.add_listener
+def _(environment, **kw):
+    try:
+        app_config_path = file_path(environment.parsed_options.app_config)
+        APP_CONFIG.update(load_json_data(app_config_path))
+        logger.info("Loaded app config")
+    except Exception as e:
+        logger.error("Error loading app config: %s", e)
+        raise InterruptTaskSet from e
+    try:
+        user_path = file_path(environment.parsed_options.user_details)
+        user_data = load_json_data(user_path)["user"]
+        USERS_DETAILS.set([UserDetails(**user) for user in user_data])
+        logger.info("Loaded %s users", len(USERS_DETAILS.items))
+    except Exception as e:
+        logger.error("Error loading users: %s", e)
+        raise InterruptTaskSet from e
+
+
+class WorkloadModelSteps(SequentialTaskSet):
+    wait_time = between(3, 7)
+
+    def on_start(self):
+        self.FUNC_HOME_SCREEN = APP_CONFIG['FUNC_HOME_SCREEN']
+        self.FUNC_REAF_MEN = APP_CONFIG['FUNC_REAF_MEN']
+        self.FUNC_ANSWER_HOUSEHOLD = APP_CONFIG['FUNC_ANSWER_HOUSEHOLD']
+        self.FUNC_REASSIGN_HOUSEHOLD_FORM = APP_CONFIG["FUNC_REASSIGN_HOUSEHOLD_FORM"]
+        self.FUNC_HOUSEHOLD_FORM_SUBMIT = APP_CONFIG['FUNC_HOUSEHOLD_FORM_SUBMIT']
+
+    @tag('home_screen')
+    @task
+    def home_screen(self):
+        self.user.hq_user.navigate_start(expected_title=self.FUNC_HOME_SCREEN['title'])
+        logger.info("Open Home Screen for mobile worker " + self.user.user_detail.username)
+
+    @task
+    def answer_and_submit_reassign_household_form(self):
+        logging.info("Generating names")
+        if "kb_test_1" in self.user.user_detail.username:
+            n = 3
+        else:
+            n = 4001
+        for i in range(1, n):
+            rc_list = list(range(1, i + 1))
+            session_id = self.reaf_men(str(i))
+            self.submit_reassign_household_form(session_id, rc_list, str(i))
+
+    @tag('open_reaf_men_form')
+    # @task
+    def reaf_men(self, count):
+        wrong_string = self.FUNC_REAF_MEN['title']
+        title = wrong_string.encode('latin1').decode('utf-8')
+        data = self.user.hq_user.navigate(
+            "Open 'Reassign Household' Form",
+            data={"selections": self.FUNC_REAF_MEN['selections']},
+            expected_title=title
+            )
+        self.session_id = data['session_id']
+        logger.info("Open 'Reassign Household' Form with session id: " + str(self.session_id
+                                                                        ) + " for mobile worker " + self.user.user_detail.username +
+                    " for loop count" + str(count)
+                    )
+        return self.session_id
+
+    @tag('submit_add_household_form')
+    def submit_reassign_household_form(self, session_id, rc_list, count):
+            logging.info(str(session_id)+" "+count)
+            logging.info(rc_list)
+            answers = {
+                "1": 1,
+                "2,0": 1,
+                "2,1": 1,
+                "2,2": 1,
+                "2,3": 2,
+                "2,4": "OK",
+                "2,5,0": rc_list,
+                "3,1": "OK",
+                "4,0": 1,
+                "4,1": 1,
+                "4,2": 1,
+                "4,3": 1,
+                "4,4": "OK",
+                "5,1": "OK",
+                "5,2": "OK",
+                "5,3": 1
+        }
+            input_answers = {d["ix"]: d["answer"] for d in self.FUNC_REASSIGN_HOUSEHOLD_FORM["questions"].values()}
+            answers.update(input_answers)
+
+            extra_json = {
+                "answers": answers,
+                "prevalidated": True,
+                "debuggerEnabled": True,
+                "session_id": session_id,
+                }
+            wrong_string = self.FUNC_HOUSEHOLD_FORM_SUBMIT['submitResponseMessage']
+            expected_response_message = wrong_string.encode('latin1').decode('utf-8')
+            self.user.hq_user.submit_all(
+                "Submit Reassign Household Form",
+                extra_json,
+                expected_response_message=expected_response_message
+                )
+            logging.info(
+                "Reassign Household submitted successfully - mobile worker:" + self.user.user_detail.username + " and session id: " + str(
+                    session_id
+                    ) + " for loop count" + str(count)+" ; request: submit_all"
+                )
+    @task
+    def stop(self):
+        self.interrupt()
+
+class LoginCommCareHQWithUniqueUsers(BaseLoginCommCareUser):
+    tasks = [WorkloadModelSteps]
+    wait_time = between(3, 7)
+
+    def on_start(self):
+        super().on_start(
+            domain=self.environment.parsed_options.domain,
+            host=self.environment.parsed_options.host,
+            user_details=USERS_DETAILS,
+            build_id=self.environment.parsed_options.build_id,
+            app_id=self.environment.parsed_options.app_id
+            )

--- a/LocustScripts/update-scripts/commcarehq-v2-rc.py
+++ b/LocustScripts/update-scripts/commcarehq-v2-rc.py
@@ -1,0 +1,179 @@
+import logging
+import random
+import string
+
+import time
+from datetime import datetime
+
+from locust import SequentialTaskSet, between, task, tag, events
+from locust.exception import InterruptTaskSet
+
+from user.models import UserDetails, BaseLoginCommCareUser
+from common.args import file_path
+from common.utils import RandomItems, load_json_data
+import coloredlogs
+
+logger = logging.getLogger(__name__)
+level_styles = {
+    'critical': {'color': 'red', 'bold': True},
+    'error': {'color': 'red'},
+    'warning': {'color': 'yellow'},
+    'debug': {'color': 'green', 'bold': True},
+    'notset': {'color': 'cyan'},
+    'info': {'color': 'white'}
+    }
+coloredlogs.install(logger=logger, level='DEBUG', level_styles=level_styles
+                    )  # install a handler on the root logger with level debug
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    # Use below command to execute these tests:
+    # locust -f .\LocustScripts\update-scripts\oncho_load\commcarehq-v2-rc.py --domain alafiacomm --build-id e9737bf399694c39910a5f885a0956d4 --app-id 08a1b1951e554a459f3bc6c8d08cd42e --app-config .\LocustScripts\update-scripts\project-config\alafiacomm-perf\app_config_v2_rc.json --user-details .\LocustScripts\update-scripts\project-config\alafiacomm-perf\mobile_worker_rc_credentials.json
+
+    parser.add_argument("--domain", help="CommCare domain", required=True, env_var="COMMCARE_DOMAIN")
+    parser.add_argument("--build-id", help="CommCare build id", required=True, env_var="COMMCARE_APP_ID")
+    parser.add_argument("--app-id", help="CommCare app id", required=True, env_var="COMMCARE_APP_ID")
+    parser.add_argument("--app-config", help="Configuration of CommCare app", required=True)
+    parser.add_argument("--user-details", help="Path to user details file", required=True)
+
+
+APP_CONFIG = {}
+USERS_DETAILS = RandomItems()
+
+
+@events.init.add_listener
+def _(environment, **kw):
+    try:
+        app_config_path = file_path(environment.parsed_options.app_config)
+        APP_CONFIG.update(load_json_data(app_config_path))
+        logger.info("Loaded app config")
+    except Exception as e:
+        logger.error("Error loading app config: %s", e)
+        raise InterruptTaskSet from e
+    try:
+        user_path = file_path(environment.parsed_options.user_details)
+        user_data = load_json_data(user_path)["user"]
+        USERS_DETAILS.set([UserDetails(**user) for user in user_data])
+        logger.info("Loaded %s users", len(USERS_DETAILS.items))
+    except Exception as e:
+        logger.error("Error loading users: %s", e)
+        raise InterruptTaskSet from e
+
+
+class WorkloadModelSteps(SequentialTaskSet):
+    wait_time = between(3, 7)
+
+    def on_start(self):
+        self.FUNC_HOME_SCREEN = APP_CONFIG['FUNC_HOME_SCREEN']
+        self.FUNC_GES_MEN = APP_CONFIG['FUNC_GES_MEN']
+        self.FUNC_ADD_HOUSEHOLD = APP_CONFIG['FUNC_ADD_HOUSEHOLD']
+        self.FUNC_HOUSEHOLD_FORM = APP_CONFIG["FUNC_HOUSEHOLD_FORM"]
+        self.FUNC_HOUSEHOLD_FORM_SUBMIT = APP_CONFIG['FUNC_HOUSEHOLD_FORM_SUBMIT']
+
+    @tag('home_screen')
+    @task
+    def home_screen(self):
+        self.user.hq_user.navigate_start(expected_title=self.FUNC_HOME_SCREEN['title'])
+        logger.info("Open Home Screen for mobile worker " + self.user.user_detail.username)
+
+    @tag('ges_men')
+    @task
+    def ges_men(self):
+        self.user.hq_user.navigate(
+            "Open 'Ges Men' Menu",
+            data={"selections": [self.FUNC_GES_MEN['selections']]},
+            expected_title=self.FUNC_GES_MEN['title']
+            )
+        logger.info("Open 'Ges Men' Menu for mobile worker " + self.user.user_detail.username)
+
+    @task
+    def answer_and_submit_add_household_form(self):
+        logging.info("Generating names")
+        for i in range(0, 3000):
+            random_string = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
+            fname = "FName" + str(i) + str(random_string)
+            lname = "LName" + str(i) + str(random_string)
+            address = "Home Add" + str(i) + str(random_string)
+            session_id = self.move_household_form()
+            # self.answer_add_household_form(session_id)
+            self.submit_add_household_form(session_id, str(fname), str(lname), str(address))
+
+    @tag('move_household_form')
+    # @task
+    def move_household_form(self):
+        data = self.user.hq_user.navigate(
+            "Open 'Add Household' Form",
+            data={"selections": self.FUNC_ADD_HOUSEHOLD['selections']},
+            expected_title=self.FUNC_ADD_HOUSEHOLD['title']
+            )
+        self.session_id = data['session_id']
+        logger.info("Open 'Add Household' Form with session id: " + str(self.session_id
+                                                                        ) + " for mobile worker " + self.user.user_detail.username
+                    )
+        return self.session_id
+
+    @tag('submit_add_household_form')
+    # @task
+    def submit_add_household_form(self, session_id, fname, lname, address):
+            logging.info(str(session_id)+" "+fname+" "+lname+" "+address)
+            answers = {
+                "3,0": "OK",
+                "3,2": [53.74871079689897, 28.125699783533644],
+                # "4,0":"OK",
+                "4,2": fname,
+                "4,3": lname,
+                "4,4": 1,
+                "4,5": None,
+                "4,6": None,
+                "4,7": 1,
+                "4,8,0": 2,
+                "4,8,2": 30,
+                "4,8,3": 2,
+                "4,8,4": 2,
+                "5,0": address,
+                "5,1": 1,
+                "5,3": 1,
+                "5,4": 1,
+                "5,5": 1,
+                "5,6": 1,
+                "5,7,0": 2,
+                "5,7,1": 2,
+                "6,0": "OK",
+                "6,6": "OK"
+                }
+            input_answers = {d["ix"]: d["answer"] for d in self.FUNC_HOUSEHOLD_FORM["questions"].values()}
+            answers.update(input_answers)
+
+            extra_json = {
+                "answers": answers,
+                "prevalidated": True,
+                "debuggerEnabled": True,
+                "session_id": session_id,
+                }
+            self.user.hq_user.submit_all(
+                "Submit Add Household Form",
+                extra_json,
+                expected_response_message=self.FUNC_HOUSEHOLD_FORM_SUBMIT['submitResponseMessage']
+                )
+            logging.info(
+                "Add Household submitted successfully - mobile worker:" + self.user.user_detail.username + " and session id: " + str(
+                    session_id
+                    ) + " ; request: submit_all"
+                )
+    @task
+    def stop(self):
+        self.interrupt()
+
+class LoginCommCareHQWithUniqueUsers(BaseLoginCommCareUser):
+    tasks = [WorkloadModelSteps]
+    wait_time = between(3, 7)
+
+    def on_start(self):
+        super().on_start(
+            domain=self.environment.parsed_options.domain,
+            host=self.environment.parsed_options.host,
+            user_details=USERS_DETAILS,
+            build_id=self.environment.parsed_options.build_id,
+            app_id=self.environment.parsed_options.app_id
+            )

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/app_config_v2_it_test.json
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/app_config_v2_it_test.json
@@ -1,0 +1,87 @@
+{
+    "FUNC_HOME_SCREEN": {
+        "title": "Alafiacomm V2 IT"
+    },
+    "FUNC_REAF_MEN": {
+        "selections": ["1"],
+        "title": "Réaffecter Ménage - ONCHO"
+    },
+    "FUNC_REASSIGN_HOUSEHOLD_FORM": {
+        "selections": ["1"],
+        "title": "Réaffecter Ménage - ONCHO",
+        "questions": {
+            "QUESTION_MOVE_HOUSEHOLD": {
+                "ix": "1",
+                "answer": 1
+            },
+            "QUESTION_INITIAL_DISTRICT": {
+                "ix": "2,0",
+                "answer": 1
+            },
+            "QUESTION_INITIAL_HEALTH_TRAINING": {
+                "ix": "2,1",
+                "answer": 1
+            },
+            "QUESTION_INITIAL_VILLAGE": {
+                "ix": "2,2",
+                "answer": 1
+            },
+            "QUESTION_INITIAL_RC": {
+                "ix": "2,3",
+                "answer": 1
+            },
+            "QUESTION_SELECT_HOUSEHOLD": {
+                "ix": "2,5,0",
+                "answer": [
+                    1,
+                    2
+                ]
+            },
+            "QUESTION_FINAL_DISTRICT": {
+                "ix": "4,0",
+                "answer": 1
+            },
+            "QUESTION_FINAL_HEALTH_TRAINING": {
+                "ix": "4,1",
+                "answer": 1
+            },
+            "QUESTION_FINAL_VILLAGE": {
+                "ix": "4,2",
+                "answer": 1
+            },
+            "QUESTION_FINAL_RC": {
+                "ix": "4,3",
+                "answer": 1
+            },
+            "QUESTION_CONFIRM": {
+                "ix": "5,3",
+                "answer": 1
+            }
+        }
+    },
+    "FUNC_ANSWER_HOUSEHOLD": {
+        "answers": {"1": 1,
+                "2,0": 1,
+                "2,1": 1,
+                "2,2": 1,
+                "2,3": 2,
+                "2,4": "OK",
+                "2,5,0": [
+                    1,
+                    2
+                ],
+                "3,1": "OK",
+                "4,0": 1,
+                "4,1": 1,
+                "4,2": 1,
+                "4,3": 1,
+                "4,4": "OK",
+                "5,1": "OK",
+                "5,2": "OK",
+                "5,3": 1
+        }
+    },
+    "FUNC_HOUSEHOLD_FORM_SUBMIT": {
+        "submitResponseMessage": "'Réaffecter Ménage - ONCHO' successfully saved!"
+    }
+}

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/app_config_v2_rc_test.json
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/app_config_v2_rc_test.json
@@ -1,0 +1,95 @@
+{
+    "FUNC_HOME_SCREEN": {
+        "title":"AlafiaComm v2 RC - For QA test"
+    },
+    "FUNC_GES_MEN": {
+        "selections":"0", "title":"Gestion Menage"
+    },
+    "FUNC_ADD_HOUSEHOLD": {
+        "selections": ["0", "action 0"], "title": "Ajouter Menage"
+    },
+    "FUNC_HOUSEHOLD_FORM": {
+        "selections": ["0", "action 0"], "title": "Ajouter Menage",
+        "questions": {
+            "QUESTION_LOC": {
+                "ix":"3,2","answer":[24.206889622398023,25.83550155767534]
+            },
+            "QUESTION_FIRST_NAME": {
+                "ix": "4,2", "answer": "First name"
+            },
+            "QUESTION_LAST_NAME": {
+                "ix": "4,3", "answer": "LAST NAME"
+            },
+            "QUESTION_GENDER": {
+                "ix": "4,4", "answer": 1
+            },
+            "QUESTION_PIN_YES": {
+                "ix": "4,7", "answer": 1
+            },
+            "QUESTION_AGE_YES": {
+                "ix": "4,8,0", "answer": 2
+            },
+            "QUESTION_AGE_YEARS": {
+                "ix": "4,8,2", "answer": 30
+            },
+            "QUESTION_STATUS": {
+                 "ix": "4,8,3", "answer": 2
+            },
+            "QUESTION_HOME": {
+                 "ix": "5,0", "answer": "Home 1"
+            },
+            "QUESTION_LATRINES": {
+                "ix": "5,1", "answer": 1
+            },
+            "QUESTION_HAND_WASH": {
+                 "ix": "5,3", "answer": 1
+            },
+            "QUESTION_CLEAN_ENV": {
+                "ix": "5,4", "answer": 1
+            },
+            "QUESTION_DRINKING_WATER": {
+                "ix": "5,5", "answer": 1
+            },
+            "QUESTION_MECHANICAL_PROTECTION": {
+                "ix": "5,6", "answer": 1
+            },
+            "QUESTION_LLINS": {
+                "ix": "5,7,0", "answer": 2
+            },
+            "QUESTION_MOSQUITOES": {
+                "ix": "5,7,1", "answer": 2
+            }
+        }
+    },
+    "FUNC_ANSWER_HOUSEHOLD": {
+        "answers":{"3,0":"OK",
+        "3,2":[53.74871079689897,28.125699783533644],
+        "4,0":"OK",
+        "4,2":"Fn",
+        "4,3":"Ln",
+        "4,4":2,
+        "4,5":null,
+        "4,6":null,
+        "4,7":1,
+        "4,8,0":2,
+        "4,8,2":30,
+        "4,8,3":2,
+        "4,8,4":2,
+        "5,0":"1234qq",
+        "5,1":1,
+        "5,3":1,
+        "5,4":1,
+        "5,5":1,
+        "5,6":1,
+        "5,7,0":2,
+        "5,7,1":2,
+        "6,0":"OK",
+        "6,6":"OK"}
+    },
+    "FUNC_SEARCH_HOUSEHOLD": {
+        "search_text": "Fn Ln" ,"selections":["0"], "title":"Gestion Menage"
+    },
+    "FUNC_HOUSEHOLD_FORM_SUBMIT": {
+        "submitResponseMessage": "'Ajouter Menage' successfully saved!"
+    }
+}

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/mobile_worker_it_credentials.json
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/mobile_worker_it_credentials.json
@@ -1,0 +1,14 @@
+{
+    "user": [
+      {"username": "kb_test_1@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_2@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_3@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_4@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_5@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_6@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_7@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_8@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_9@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_10@alafiacomm.commcarehq.org","password": " "}
+    ]
+}

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/mobile_worker_rc_credentials.json
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/mobile_worker_rc_credentials.json
@@ -1,0 +1,14 @@
+{
+    "user": [
+      {"username": "kb_test_rc1@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc2@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc3@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_4@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_5@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_6@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_7@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_8@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_9@alafiacomm.commcarehq.org","password": " "},
+      {"username": "kb_test_rc_10@alafiacomm.commcarehq.org","password": " "}
+    ]
+}

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/v2_it.yaml
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/v2_it.yaml
@@ -1,0 +1,7 @@
+host: https://www.commcarehq.org
+domain: alafiacomm
+app_id: 791fcbb98a0c4ffeb4aa38f20fd3544b
+build_id: e010117e07ab3f47a1fdad6da7f0bfb9
+domain_user_credential: LocustScripts/update-scripts/project-config/alafiacomm-perf/mobile_worker_it_credentials.json
+owner_id: 3913fc73f18a4681a3686abc819a0e7c
+app_config_bed_tracking_tool: LocustScripts/update-scripts/project-config/alafiacomm-perf/app_config_v2_it_test.json

--- a/LocustScripts/update-scripts/project-config/co-carecoordination-perf/v2_rc.yaml
+++ b/LocustScripts/update-scripts/project-config/co-carecoordination-perf/v2_rc.yaml
@@ -1,0 +1,7 @@
+host: https://www.commcarehq.org
+domain: alafiacomm
+app_id: 08a1b1951e554a459f3bc6c8d08cd42e
+build_id: e9737bf399694c39910a5f885a0956d4
+domain_user_credential: LocustScripts/update-scripts/project-config/co-carecoordination-perf/mobile_worker_rc_credentials.json
+owner_id: 3913fc73f18a4681a3686abc819a0e7c
+app_config_bed_tracking_tool: LocustScripts/update-scripts/project-config/co-carecoordination-perf/app_config_v2_rc_test.json


### PR DESCRIPTION
## Summary
 Added the test scripts for V2 RC and V2 IT apps load tests

## Description
Added the test scripts for V2 RC and V2 IT apps load tests
- the V2 RC script creates households
- the V2 IT script reassigns household from 1 RC to another..

### Link to Jira Ticket (if applicable)
[Jira link](https://dimagi-dev.atlassian.net/browse/QA-7428)

## QA Checklist

- [X] Label(s) and Assignee added
- [X] PR sent for review
- [ ] Documentation (if applicable) added/updated